### PR TITLE
Added int64 pointers

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 39, 7
+version_info = 0, 39, 8
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/cython/_binary_reader.pyx
+++ b/pyansys/cython/_binary_reader.pyx
@@ -54,9 +54,9 @@ cdef extern from "numpy/npy_math.h" nogil:
     bint npy_isnan(double x)
 
 cdef extern from 'binary_reader.h' nogil:
-    void read_nodes(const char*, int, int, int*, double*)
-    void* read_record(const char*, int, int*, int*, int*, int*)
-    void read_record_stream(ifstream*, int, void*, int*, int*, int*)
+    void read_nodes(const char*, int64_t, int, int*, double*)
+    void* read_record(const char*, int64_t, int*, int*, int*, int*)
+    void read_record_stream(ifstream*, int64_t, void*, int*, int*, int*)
 
 
 # VTK numbering for vtk cells
@@ -188,7 +188,7 @@ def load_nodes(filename, int ptr_loc, int nnod, double [:, ::1] nloc,
     read_nodes(c_filename, ptr_loc, nnod, &nnum[0], &nloc[0, 0])
 
 
-def c_read_record(filename, int ptr, int return_bufsize=0):
+def c_read_record(filename, int64_t ptr, int return_bufsize=0):
     """Read an ANSYS record and return a numpy array"""
     cdef bytes py_bytes = filename.encode()
     cdef char* c_filename = py_bytes
@@ -236,7 +236,7 @@ cdef np.ndarray wrap_array(void* c_ptr, int size, int type_flag, int prec_flag):
     return ndarray
 
 
-def load_elements(filename, int loc, int nelem, int64_t [::1] e_disp_table,
+def load_elements(filename, int64_t loc, int nelem, int64_t [::1] e_disp_table,
                    int [:, ::1] elem, int [::1] etype, int [::1] mtype,
                    int [::1] rcon):
     """The following is stored for each element
@@ -263,7 +263,8 @@ def load_elements(filename, int loc, int nelem, int64_t [::1] e_disp_table,
     cdef int* element
     cdef short* s_element
 
-    cdef int val, nread, elem_loc
+    cdef int val, nread
+    cdef int64_t elem_loc
     for i in range(nelem):
         # load element
         elem_loc = loc + e_disp_table[i]
@@ -367,12 +368,13 @@ def read_element_stress(filename, int64_t [::1] ele_ind_table,
         c += nnode_elem
 
 
-cdef inline int read_element_result_float(ifstream *binfile, int ele_table,
+cdef inline int read_element_result_float(ifstream *binfile, int64_t ele_table,
                                     int result_index,
                                     int nnode_elem, int nitem, float *arr,
                                     int element_type, int as_global=1):
     """Populate array with results from a single element"""
-    cdef int i, j, k, c, ptr
+    cdef int i, j, k, c,
+    cdef int64_t ptr
     cdef int [4096] pointers  # tmp array of pointers
     cdef int prec_flag, type_flag, size
     cdef float [64] tmpbuffer  # for euler results

--- a/pyansys/cython/binary_reader.cpp
+++ b/pyansys/cython/binary_reader.cpp
@@ -11,6 +11,7 @@ using namespace std;
 #define	MEMCOPY(from,to,n_items,type) MEM_COPY((char *)(from),(char *)(to),(unsigned)(n_items)*sizeof(type))
 #define IS_ON(e,p)   ((e) & (1u << (p)))
 
+// int64_t
 
 static int NbBitsOn( int iVal)
 {
@@ -103,7 +104,8 @@ int read_header(ifstream* binFile, int* bsparse_flag, int* wsparse_flag,
 }
 
 
-void read_nodes(const char* filename, int ptrLOC, int nrec, int *nnum, double *nodes){
+void read_nodes(const char* filename, int64_t ptrLOC, int nrec, int *nnum,
+		double *nodes){
 
   // max buf size
   char *raw = new char[68*4];
@@ -455,7 +457,7 @@ char* ReadWindowedSparseBufferShort(int *raw, int *size, short *vec){
 
 
 // read a record and return the pointer to the array
-void* read_record(const char* filename, int ptr, int* prec_flag, int* type_flag,
+void* read_record(const char* filename, int64_t ptr, int* prec_flag, int* type_flag,
 		  int* size, int* out_bufsize){
 
   int bsparse_flag, wsparse_flag, zlib_flag;
@@ -509,7 +511,7 @@ void* read_record(const char* filename, int ptr, int* prec_flag, int* type_flag,
 
 // populate arr with a record
 // This function differs from read_record as it must be supplied with ``arr``, which must be sized properly to support the data coming from the file.
-void read_record_stream(ifstream* file, int loc, void* arr, int* prec_flag,
+void read_record_stream(ifstream* file, int64_t loc, void* arr, int* prec_flag,
 			 int* type_flag, int* size){
 
   // seek to data location if supplied with a pointer

--- a/pyansys/cython/binary_reader.cpp
+++ b/pyansys/cython/binary_reader.cpp
@@ -4,6 +4,11 @@
 #include <fstream>
 #include <exception>
 
+// necessary for ubuntu build on azure
+#ifdef __linux__
+  #include <stdint.h>
+#endif
+
 using namespace std;
 
 #define	MEM_ZERO(where,size)	memset((where),'\0',(size))
@@ -11,7 +16,6 @@ using namespace std;
 #define	MEMCOPY(from,to,n_items,type) MEM_COPY((char *)(from),(char *)(to),(unsigned)(n_items)*sizeof(type))
 #define IS_ON(e,p)   ((e) & (1u << (p)))
 
-// int64_t
 
 static int NbBitsOn( int iVal)
 {

--- a/pyansys/cython/binary_reader.h
+++ b/pyansys/cython/binary_reader.h
@@ -1,5 +1,5 @@
 /* #include <fstream> */
 
-void read_nodes(const char*, int, int, int *, double *);
-void* read_record(const char*, int, int*, int*, int*, int*);
-void read_record_stream(std::ifstream*, int, void*, int*, int*, int*);
+void read_nodes(const char*, int64_t, int, int *, double *);
+void* read_record(const char*, int64_t, int*, int*, int*, int*);
+void read_record_stream(std::ifstream*, int64_t, void*, int*, int*, int*);

--- a/pyansys/rst.py
+++ b/pyansys/rst.py
@@ -1119,13 +1119,12 @@ class ResultFile(AnsysBinary):
     def _element_solution_header(self, rnum):
         """ Get element solution header information """
         # Get the header information from the header dictionary
-        # endian = self.resultheader['endian']
+
         rpointers = self.resultheader['rpointers']
-        nelm = self.resultheader['nelm']
         nodstr = self.element_table['nodstr']
         etype = self.geometry['etype']
 
-        # read result solution header 
+        # read result solution header
         record = self.read_record(rpointers[rnum])
         solution_header = parse_header(record, SOLUTION_DATA_HEADER_KEYS)
 


### PR DESCRIPTION
32-bit pointers were causing segfaults when reading beyond `2^32` bits.  Using int64 fixes this.