### PR TITLE
fixed stitle for various plotting methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ tests/htmlcov
 tests/cyclic/htmlcov
 .coverage
 *,cover
-
+flycheck*
 
 # ignore certain result files
 tests/testfiles/is16.rst

--- a/pyansys/rst.py
+++ b/pyansys/rst.py
@@ -277,15 +277,6 @@ class ResultFile(AnsysBinary):
         """Reads in coordinate system information from a binary result
         file.
 
-        Parameters
-        ----------
-        f : file object
-            Open binary result file.
-
-        geometry_header, dict
-            Dictionary containing pointers to geometry items in the ansys
-            result.
-
         Returns
         -------
         c_systems : dict
@@ -1467,8 +1458,9 @@ class ResultFile(AnsysBinary):
     def _plot_point_scalars(self, scalars, rnum=None, grid=None,
                             show_displacement=False, displacement_factor=1,
                             add_text=True, animate=False, nangles=100,
-                            overlay_wireframe=False,
-                            movie_filename=None, max_disp=0.1, **kwargs):
+                            overlay_wireframe=False, node_components=None,
+                            sel_type_all=True, movie_filename=None,
+                            max_disp=0.1, **kwargs):
         """Plot point scalars on active mesh.
 
         Parameters
@@ -1512,9 +1504,14 @@ class ResultFile(AnsysBinary):
         disp = None
         if show_displacement and not animate:
             disp = self.nodal_solution(rnum)[1][:, :3]*displacement_factor
+            if node_components:
+                _, ind = self._extract_node_components(node_components, sel_type_all)
+                disp = disp[ind]
+
             new_points = disp + grid.points
             grid = grid.copy()
             grid.points = new_points
+
         elif animate:
             disp = self.nodal_solution(rnum)[1][:, :3]
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,4 @@
+matplotlib
 Sphinx
 sphinx-autobuild
 sphinx-rtd-theme

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -68,6 +68,13 @@ def test_read_volume():
 
 
 @pytest.mark.skipif(vm33 is None, reason="Requires example files")
+def nodal_displacement():
+    nnum, disp = vm33.nodal_displacement(0)
+    assert isinstance(nnum, np.ndarray)
+    assert isinstance(disp, np.ndarray)
+
+
+@pytest.mark.skipif(vm33 is None, reason="Requires example files")
 def test_nodal_thermal_strain():
     _, tstrain = vm33.nodal_thermal_strain(0)
     assert np.any(tstrain)
@@ -110,6 +117,13 @@ def test_plot_pontoon():
 def test_plot_pontoon_nodal_displacement():
     pontoon.plot_nodal_solution(0, show_displacement=True,
                                 overlay_wireframe=True, off_screen=True)
+
+
+@pytest.mark.skipif(not system_supports_plotting(), reason="Requires active X Server")
+@pytest.mark.skipif(pontoon is None, reason="Requires example files")
+def test_plot_pontoon_nodal_displacement():
+    pontoon.plot_nodal_displacement(0, show_displacement=True,
+                                    overlay_wireframe=True, off_screen=True)
 
 
 @pytest.mark.skipif(pontoon is None, reason="Requires example files")

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -108,7 +108,7 @@ def test_plot_pontoon():
 @pytest.mark.skipif(not system_supports_plotting(), reason="Requires active X Server")
 @pytest.mark.skipif(pontoon is None, reason="Requires example files")
 def test_plot_pontoon_nodal_displacement():
-    pontoon.plot_nodal_solution(0, show_displacement=True, max_disp=10,
+    pontoon.plot_nodal_solution(0, show_displacement=True,
                                 overlay_wireframe=True, off_screen=True)
 
 


### PR DESCRIPTION
This is a minor PR that fixes the scalar bar for plotting with ``plot_principal_nodal_stress`` and a few other methods.

Additionally, it adds the method ``plot_nodal_displacement`` as this is a bit more familiar than ``plot_nodal_solution``.  Methods are wrapped to avoid code duplication.

![image](https://user-images.githubusercontent.com/11981631/78743714-aed0e080-795f-11ea-9de4-fb1b99c61f1c.png)
