### PR TITLE
Fix triangle parsing and add surface support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,14 +86,14 @@ jobs:
     - template: .ci/azure-steps.yml
     - template: .ci/azure-publish-dist.yml
 
-- job: build_docs
-  variables:
-    gh_user: akaszynski
-    gh_repo: pyansys.github.io
-    gh_pass: $(github_pat)
-    gh_email: $(github_email)
-    gh_auth_header: $(echo -n "${gh_user}:$(github_pat)" | base64);
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-    - template: .ci/build_documentation.yml
+# - job: build_docs
+#   variables:
+#     gh_user: akaszynski
+#     gh_repo: pyansys.github.io
+#     gh_pass: $(github_pat)
+#     gh_email: $(github_email)
+#     gh_auth_header: $(echo -n "${gh_user}:$(github_pat)" | base64);
+#   pool:
+#     vmImage: 'ubuntu-16.04'
+#   steps:
+#     - template: .ci/build_documentation.yml

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,6 +19,17 @@ clean:
 	rm -rf examples/
 	rm -f errors.txt
 
+deploy:
+	rm -rf /tmp/pyansys
+	cd /tmp; git clone --single-branch --branch gh-pages https://$(github_pat)@github.com/akaszynski/pyansys.git
+	rm -rf /tmp/pyansys/*
+	cp -r _build/html/* /tmp/pyansys/
+	touch /tmp/pyansys/.nojekyll
+	cd /tmp/pyansys; git add .
+	cd /tmp/pyansys; git commit -am "Manual build"
+	cd /tmp/pyansys; git push
+
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/apdl_conversion.rst
+++ b/docs/apdl_conversion.rst
@@ -26,7 +26,7 @@ conjunction with ``mapdl.load_parameters``.  For example:
    mapdl.get('DEF_Y', 'NODE' , 2, 'U' ,'Y')
    mapdl.load_parameters()
 
-The parameters are now acessable within the ``ANSYS`` object:
+The parameters are now accessible within the ``ANSYS`` object:
 
 .. code:: python
 

--- a/examples/01-mapdl-examples/README.txt
+++ b/examples/01-mapdl-examples/README.txt
@@ -1,0 +1,2 @@
+ANSYS MAPDL examples with Pyansys
+---------------------------------

--- a/examples/01-mapdl-examples/pyvista_mesh.py
+++ b/examples/01-mapdl-examples/pyvista_mesh.py
@@ -18,7 +18,7 @@ mapdl = pyansys.launch_mapdl(loglevel='WARNING', override=True)
 mesh = pv.Plane(i_resolution=100, j_resolution=100)
 
 mesh.plot(color='w', show_edges=True)
-
+ 
 ###############################################################################
 # Write the mesh to an archive file
 archive_filename = os.path.join(mapdl.path, 'tmp.cdb')

--- a/examples/01-mapdl-examples/pyvista_mesh.py
+++ b/examples/01-mapdl-examples/pyvista_mesh.py
@@ -1,0 +1,77 @@
+"""
+.. _ref_pyvista_mesh:
+
+PyVista Mesh Integration
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run a modal analysis from a mesh generated from pyvista within MAPDL
+
+"""
+import os
+import pyvista as pv
+import pyansys
+
+# launch MAPDL and run a modal analysis
+mapdl = pyansys.launch_mapdl(loglevel='WARNING', override=True)
+
+# Create a simple plane mesh centered at (0, 0, 0) on the XY plane
+mesh = pv.Plane(i_resolution=100, j_resolution=100)
+
+mesh.plot(color='w', show_edges=True)
+
+###############################################################################
+# Write the mesh to an archive file
+archive_filename = os.path.join(mapdl.path, 'tmp.cdb')
+pyansys.save_as_archive(archive_filename, mesh)
+
+
+###############################################################################
+# mapdl = pyansys.launch_mapdl(prefer_pexpect=True, override=True)
+
+# Read in the archive file
+response = mapdl.cdread('db', archive_filename)
+mapdl.prep7()
+print(mapdl.shpp('SUMM'))
+
+# specify shell thickness
+mapdl.sectype(1, "shell")
+mapdl.secdata(0.01)
+mapdl.emodif('ALL', 'SECNUM', 1)
+
+# specify material properties
+# using aprox values for AISI 5000 Series Steel
+# http://www.matweb.com/search/datasheet.aspx?matguid=89d4b891eece40fbbe6b71f028b64e9e
+mapdl.units('SI')  # not necessary, but helpful for book keeping
+mapdl.mp('EX', 1, 200E9)  # Elastic moduli in Pa (kg/(m*s**2))
+mapdl.mp('DENS', 1, 7800)  # Density in kg/m3
+mapdl.mp('NUXY', 1, 0.3)  # Poissons Ratio
+mapdl.emodif('ALL', 'MAT', 1)
+
+# Run an unconstrained modal analysis
+mapdl.run('/SOLU')
+mapdl.antype('MODAL')  # default NEW
+mapdl.modopt('LANB', 20, 1)  # First 6 modes above 1 Hz
+mapdl.solve()
+
+###############################################################################
+# Load the result file within pyansys
+result = mapdl.result
+
+# Plot the 8th mode
+result.plot_nodal_displacement(7, show_displacement=True, displacement_factor=0.4)
+
+###############################################################################
+# plot the 1st mode using contours
+result.plot_nodal_displacement(0, show_displacement=True,
+                               displacement_factor=0.4, n_colors=10)
+
+###############################################################################
+# Animate a high frequency mode
+result.animate_nodal_displacement(18, loop=False, add_text=False,
+                                  nangles=30, max_disp=0.2, show_axes=False,
+                                  background='w',
+                                  movie_filename='plane_vib.gif')
+
+# Get a smoother plot by disabling movie_filename and increasing `nangles`
+# also, enable a continous plot with `loop=True`
+

--- a/pyansys/archive.py
+++ b/pyansys/archive.py
@@ -9,6 +9,7 @@ from vtk import (VTK_TETRA, VTK_QUADRATIC_TETRA, VTK_PYRAMID,
                  VTK_HEXAHEDRON, VTK_QUADRATIC_HEXAHEDRON, VTK_TRIANGLE, VTK_QUAD,
                  VTK_QUADRATIC_TRIANGLE, VTK_QUADRATIC_QUAD)
 import vtk
+import pyvista as pv
 
 from pyansys import _reader
 from pyansys.misc import vtk_cell_info
@@ -271,6 +272,9 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
         SOLID185).  Default True.
     """
     header = '/PREP7\n'
+
+    if isinstance(grid, pv.PolyData):
+        grid = grid.cast_to_unstructured_grid()
 
     # node numbers
     if 'ansys_node_num' in grid.point_arrays:
@@ -574,6 +578,13 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
                               nodes[1],  # 1,  J
                               nodes[2],  # 2,  K
                               nodes[2])  # 3,  L (duplicate of K)
+                line += '%8d%8d%8d%8d\n' % writenodes
+
+            elif celltypes[i] == VTK_QUAD:
+                writenodes = (nodes[0],  # 0,  I
+                              nodes[1],  # 1,  J
+                              nodes[2],  # 2,  K
+                              nodes[3])  # 3,  L
                 line += '%8d%8d%8d%8d\n' % writenodes
 
             else:

--- a/pyansys/archive.py
+++ b/pyansys/archive.py
@@ -201,10 +201,11 @@ def chunks(l, n):
 
 
 def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
-                    real_constant_start=1, mode='w',
-                    nblock=True, enum_start=1, nnum_start=1,
-                    include_etype_header=True,
-                    reset_etype=False, allow_missing=True):
+                    real_constant_start=1, mode='w', nblock=True,
+                    enum_start=1, nnum_start=1,
+                    include_etype_header=True, reset_etype=False,
+                    allow_missing=True, include_surface_elements=True,
+                    include_solid_elements=True):
     """Writes FEM as an ANSYS APDL archive file.  This function
     supports the following element types:
 
@@ -270,11 +271,41 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
         determined by the shape of the element (i.e. quadradic
         tetrahedrals will be saved as SOLID187, linear hexahedrals as
         SOLID185).  Default True.
+
+    include_surface_elements : bool, optional
+        Includes surface elements when writing the archive file and
+        saves them as SHELL181.
+
+    include_solid_elements : bool, optional
+        Includes solid elements when writing the archive file and
+        saves them as SOLID185, SOLID186, or SOLID187.
+
     """
     header = '/PREP7\n'
 
     if isinstance(grid, pv.PolyData):
         grid = grid.cast_to_unstructured_grid()
+
+    allowable = []
+    if include_solid_elements:
+        allowable.extend([VTK_TETRA,
+                          VTK_QUADRATIC_TETRA,
+                          VTK_PYRAMID,
+                          VTK_QUADRATIC_PYRAMID,
+                          VTK_WEDGE,
+                          VTK_QUADRATIC_WEDGE,
+                          VTK_HEXAHEDRON,
+                          VTK_QUADRATIC_HEXAHEDRON])
+
+    if include_surface_elements:
+        allowable.extend([VTK_TRIANGLE,
+                          VTK_QUAD])
+                          # VTK_QUADRATIC_TRIANGLE,
+                          # VTK_QUADRATIC_QUAD
+
+    # extract allowable cell types
+    mask = np.in1d(grid.celltypes, allowable)
+    grid = grid.extract_cells(mask)
 
     # node numbers
     if 'ansys_node_num' in grid.point_arrays:
@@ -587,8 +618,8 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
                               nodes[3])  # 3,  L
                 line += '%8d%8d%8d%8d\n' % writenodes
 
-            else:
-                raise RuntimeError('Invalid write cell type %d' % celltypes[i])
+            # else:
+            #     raise RuntimeError('Invalid write cell type %d' % celltypes[i])
 
             f.write(line)
 

--- a/pyansys/cyclic_reader.py
+++ b/pyansys/cyclic_reader.py
@@ -1048,7 +1048,7 @@ class CyclicResult(ResultFile):
                     plotter.textActor.SetInput('%s\nPhase %.1f Degrees' %
                                                (result_info, (angle*180/np.pi)))
 
-                plotter.update(30, force_redraw=False)
+                plotter.update(1, force_redraw=True)
 
                 if movie_filename and first_loop:
                     plotter.write_frame()

--- a/pyansys/cython/vtk_support.c
+++ b/pyansys/cython/vtk_support.c
@@ -455,7 +455,7 @@ int ans_to_vtk(int nelem, int *elem, int *elem_off, int *type_ref, int nnode,
       break;
     case 3:  // shell
       is_quad = nnode_elem > 4;
-      if (elem[off + 2] == elem[off + 13]){
+      if (elem[off + 2] == elem[off + 3]){
   	add_tri(build_offset, &elem[off], is_quad);
       } else {  // is quadrilateral
   	add_quad(build_offset, &elem[off], is_quad);

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -1169,12 +1169,11 @@ class _Mapdl(_MapdlCommands):
     @property
     def result(self):
         """Returns a binary interface to the result file."""
-        try:
-            result_path = self.inquire('RSTFILE')
+        result_path = self.inquire('RSTFILE')
+        if not result_path:
+            result_path = os.path.join(self.path, '%s.rst' % self._jobname)
             if not os.path.dirname(result_path):
                 result_path = os.path.join(self.path, '%s.rst' % result_path)
-        except:
-            result_path = os.path.join(self.path, '%s.rst' % self._jobname)
 
         if not os.path.isfile(result_path):
             raise FileNotFoundError('No results found at %s' % result_path)

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -1169,11 +1169,15 @@ class _Mapdl(_MapdlCommands):
     @property
     def result(self):
         """Returns a binary interface to the result file."""
-        result_path = self.inquire('RSTFILE')
+        try:
+            result_path = self.inquire('RSTFILE')
+        except RuntimeError:
+            result_path = ''
+
         if not result_path:
             result_path = os.path.join(self.path, '%s.rst' % self._jobname)
-            if not os.path.dirname(result_path):
-                result_path = os.path.join(self.path, '%s.rst' % result_path)
+        elif not os.path.dirname(result_path):
+            result_path = os.path.join(self.path, '%s.rst' % result_path)
 
         if not os.path.isfile(result_path):
             raise FileNotFoundError('No results found at %s' % result_path)

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -536,7 +536,7 @@ def launch_mapdl(exec_file=None, run_location=None,
                                     'pyansys.Mapdl(exec_file=...)')
     else:  # verify ansys exists at this location
         if not os.path.isfile(exec_file):
-            raise FileNotFoundError('Invalid ANSYS executable at %s'
+            raise FileNotFoundError('Invalid ANSYS executable at "%s"'
                                     % exec_file + 'Enter one manually using '
                                     'pyansys.Mapdl(exec_file=)')
 
@@ -1097,7 +1097,7 @@ class _Mapdl(_MapdlCommands):
         """
         # load ansys parameters to python
         filename = os.path.join(self.path, 'parameters.parm')
-        self.Parsav('all', filename)
+        self.parsav('all', filename)
         self.parameters, self.arrays = load_parameters(filename)
         return self.parameters, self.arrays
 
@@ -1245,19 +1245,172 @@ class _Mapdl(_MapdlCommands):
 
     def get_float(self, entity="", entnum="", item1="", it1num="",
                   item2="", it2num="", **kwargs):
-        """Get the value of a float-parameter from APDL.
+        """Runs the *GET command with a default parameter
+
+        See `help(get)` for more details.
+
+        Parameters
+        ----------
+        entity
+            Entity keyword. Valid keywords are NODE, ELEM, KP, LINE, AREA,
+            VOLU, PDS, etc., as shown for Entity = in the tables below.
+
+        entnum
+            The number or label for the entity (as shown for ENTNUM = in the
+            tables below). In some cases, a zero (or blank) ENTNUM represents
+            all entities of the set.
+
+        item1
+            The name of a particular item for the given entity. Valid items are
+            as shown in the Item1 columns of the tables below.
+
+        it1num
+            The number (or label) for the specified Item1 (if any). Valid
+            IT1NUM values are as shown in the IT1NUM columns of the tables
+            below. Some Item1 labels do not require an IT1NUM value.
+
+        item2, it2num
+            A second set of item labels and numbers to further qualify the item
+            for which data are to be retrieved. Most items do not require this
+            level of information.
+
+        Returns
+        -------
+        par : float
+            Floating point value of the parameter.
+
+        Examples
+        --------
+        Retreive the number of nodes.
+
+        >>> value = ansys.get('node', '', 'count')
+        >>> value
+        3003
+
+        Retreive the number of nodes using keywords.
+
+        >>> value = ansys.get(entity='node', item1='count')
+        >>> value
+        3003
+        """
+        return self.get(entity=entity, entnum=entnum, item1=item1, it1num=it1num,
+                        item2=item2, it2num=it2num, **kwargs)
+
+    def get(self, par="__floatparameter__", entity="", entnum="",
+            item1="", it1num="", item2="", it2num="", **kwargs):
+        """APDL Command: *GET
+
+        Retrieves a value and stores it as a scalar parameter or part
+        of an array parameter.
+
+        Parameters
+        ----------
+        par
+            The name of the resulting parameter. See *SET for name
+            restrictions.
+
+        entity
+            Entity keyword. Valid keywords are NODE, ELEM, KP, LINE, AREA,
+            VOLU, PDS, etc., as shown for Entity = in the tables below.
+
+        entnum
+            The number or label for the entity (as shown for ENTNUM = in the
+            tables below). In some cases, a zero (or blank) ENTNUM represents
+            all entities of the set.
+
+        item1
+            The name of a particular item for the given entity. Valid items are
+            as shown in the Item1 columns of the tables below.
+
+        it1num
+            The number (or label) for the specified Item1 (if any). Valid
+            IT1NUM values are as shown in the IT1NUM columns of the tables
+            below. Some Item1 labels do not require an IT1NUM value.
+
+        item2, it2num
+            A second set of item labels and numbers to further qualify the item
+            for which data are to be retrieved. Most items do not require this
+            level of information.
+
+        Returns
+        -------
+        par : float
+            Floating point value of the parameter.
+
+        Examples
+        --------
+        Retreive the number of nodes
+
+        >>> value = ansys.get('val', 'node', '', 'count')
+        >>> value
+        3003
+
+        Retreive the number of nodes using keywords.  Note that the
+        parameter name is optional.
+
+        >>> value = ansys.get(entity='node', item1='count')
+        >>> value
+        3003
 
         Notes
         -----
-        An APDL parameter __floatparameter__ is created/overwritten.
+        *GET retrieves a value for a specified item and stores the value as a
+        scalar parameter, or as a value in a user-named array parameter. An
+        item is identified by various keyword, label, and number combinations.
+        Usage is similar to the *SET command except that the parameter values
+        are retrieved from previously input or calculated results. For example,
+        *GET,A,ELEM,5,CENT,X returns the centroid x-location of element 5 and
+        stores the result as parameter A. *GET command operations, along with
+        the associated Get functions return values in the active coordinate
+        system unless stated otherwise. A Get function is an alternative in-
+        line function that can be used to retrieve a value instead of the *GET
+        command (see Using In-line Get Functions for more information).
+
+        Both *GET and *VGET retrieve information from the active data stored in
+        memory. The database is often the source, and sometimes the information
+        is retrieved from common memory blocks that the program uses to
+        manipulate information. Although POST1 and POST26 operations use a
+        *.rst file, *GET data is accessed from the database or from the common
+        blocks. Get operations do not access the *.rst file directly. For
+        repeated gets of sequential items, such as from a series of elements,
+        see the *VGET command.
+
+        Most items are stored in the database after they are calculated and are
+        available anytime thereafter. Items are grouped according to where they
+        are usually first defined or calculated. Preprocessing data will often
+        not reflect the calculated values generated from section data. Do not
+        use *GET to obtain data from elements that use calculated section data,
+        such as beams or shells. Most of the general items listed below are
+        available from all modules. Each of the sections for accessing *GET
+        parameters are shown in the following order:
+
+        *GET General Entity Items
+
+        *GET Preprocessing Entity Items
+
+        *GET Solution Entity Items
+
+        *GET Postprocessing Entity Items
+
+        *GET Probabilistic Design Entity Items
+
+        The *GET command is valid in any processor.
         """
-        line = self.get("__floatparameter__", entity, entnum, item1, it1num,
-                        item2, it2num, **kwargs)
-        return float(re.search(r"(?<=VALUE\=).*", line).group(0))
+        command = "*GET,%s,%s,%s,%s,%s,%s,%s" % (str(par),
+                                                 str(entity),
+                                                 str(entnum),
+                                                 str(item1),
+                                                 str(it1num),
+                                                 str(item2),
+                                                 str(it2num))
+        response = self.run(command, **kwargs)
+        try:
+            return float(response.split('=')[-1])
+        except:
+            return None
 
     def read_float_parameter(self, parameter_name):
         """Read out the value of a ANSYS parameter to use in python.
-        Can raise TypeError.
 
         Parameters
         ----------
@@ -1268,13 +1421,38 @@ class _Mapdl(_MapdlCommands):
         -------
         float
             Value of ANSYS parameter.
+
+        Examples
+        --------
+        >>> ansys.get('myparm', 'node', '', 'count')
+        >>> value = ansys.read_float_parameter('myparm')
+        >>> value
+        3003
+
+        Retreive the value in an array.  This example creates a block
+        of elements and stores the element numbers in an array.  Then
+        it retreives the first value of that array
+
+        >>> ansys.prep7()
+        >>> ansys.block(0,1,0,1,0,1)
+        >>> ansys.et(1, 186)
+        >>> ansys.vmesh('all')
+        >>> ansys.run('*VGET, ELEM_ARR, ELEM, , elist')
+        >>> ansys.read_float_parameter('ELEM_ARR(1)')
+        1.0
+
+        You could also retrieve ELEM_ARR with
+
+        >>> values, arrays = ansys.load_parameters()
+        >>> arrays
+        {'ELEM_ARR': array([1., 2., 3., 4., 5., 6., 7., 8.])}
+
         """
         try:
-            line = self.run(parameter_name + " = " + parameter_name)
+            response = self.run(parameter_name + " = " + parameter_name)
         except TypeError:
-            print('Input variable parameter_name should be string')
-            raise
-        return float(re.search(r"(?<=\=).*", line).group(0))
+            raise TypeError('Input variable `parameter_name` should be string')
+        return float(response.split('=')[-1])
 
     def read_float_from_inline_function(self, function_str):
         """Use a APDL inline function to get a float value from ANSYS.

--- a/pyansys/rst.py
+++ b/pyansys/rst.py
@@ -1679,7 +1679,7 @@ class ResultFile(AnsysBinary):
             first_loop = True
             cached_normals = [None for _ in range(nangles)]
             while self._animating:
-                for j, angle in enumerate(np.linspace(0, np.pi*2, nangles)):
+                for j, angle in enumerate(np.linspace(0, np.pi*2, nangles + 1)[:-1]):
                     mag_adj = np.sin(angle)
                     if scalars[0] is not None:
                         copied_mesh.active_scalars[:] = scalars[0]*mag_adj


### PR DESCRIPTION
Several fixes/changes:
- Fix triangle parsing.  Much cleaner meshes from surface elements.
- Improved archive support for surface meshes.  Added the option to save just surface/solid elements to archive.
- Added documentation support for MAPDL demos.  More to come!
- Added MAPDL PyVista interoperability demo.
- Fixed `read_float_parameter` and improved documentation for arrays
