### PR TITLE
Using static inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ tests/cyclic/htmlcov
 .coverage
 *,cover
 flycheck*
+test-output.xml
 
 # ignore certain result files
 tests/testfiles/is16.rst

--- a/pyansys/cython/_reader.pyx
+++ b/pyansys/cython/_reader.pyx
@@ -22,7 +22,8 @@ cdef extern from "reader.h":
     int read_eblock(char*, int*, int*, int, int, int*)
 
 cdef extern from 'vtk_support.h':
-    int ans_to_vtk(int, int*, int*, int*, int, int*, int64_t*, int64_t*, uint8_t*, int)
+    int ans_to_vtk(const int, const int*, const int*, const int*, const int,
+    const int*, int64_t*, int64_t*, uint8_t*, const int)
 
 cdef int myfgets(char *outstr, char *instr, int *n, int fsize):
     """Copies a single line from instr to outstr starting from position n """

--- a/pyansys/cython/vtk_support.c
+++ b/pyansys/cython/vtk_support.c
@@ -34,7 +34,7 @@ struct VtkData vtk_data;
 
 
 // Populate offset, cell type, and prepare the cell array for a cell
-__inline void add_cell(bool build_offset, int n_points, uint8_t celltype){
+static inline void add_cell(bool build_offset, int n_points, uint8_t celltype){
   if (build_offset){
     vtk_data.offset[0] = vtk_data.loc;
     vtk_data.offset++;
@@ -77,7 +77,7 @@ __inline void add_cell(bool build_offset, int n_points, uint8_t celltype){
  * 18        (2, 6)
  * 19        (3, 7)
  */
-__inline void add_hex(bool build_offset, int *elem, int nnode){
+static inline void add_hex(bool build_offset, int *elem, int nnode){
   int i;
   bool quad = nnode > 8;
   if (quad){
@@ -132,7 +132,7 @@ midedge nodes (6-14). Note that these midedge nodes correspond lie
 on the edges defined by : 
 (0,1), (1,2), (2,0), (3,4), (4,5), (5,3), (0,3), (1,4), (2,5)
 */
-__inline void add_wedge(bool build_offset, int *elem, int nnode){
+static inline void add_wedge(bool build_offset, int *elem, int nnode){
   bool quad = nnode > 8;
   if (quad){
     add_cell(build_offset, 15, VTK_QUADRATIC_WEDGE);
@@ -164,7 +164,7 @@ __inline void add_wedge(bool build_offset, int *elem, int nnode){
 }
 
 
-__inline void add_pyr(bool build_offset, int *elem, int nnode){
+static inline void add_pyr(bool build_offset, int *elem, int nnode){
   int i;  // counter
   bool quad = nnode > 8;
   if (quad){
@@ -210,7 +210,7 @@ __inline void add_pyr(bool build_offset, int *elem, int nnode){
  * point ids 4-9 are the midedge nodes between:
  * (0,1), (1,2), (2,0), (0,3), (1,3), and (2,3)
 ============================================================================ */
-__inline void add_tet(bool build_offset, int *elem, int nnode){
+static inline void add_tet(bool build_offset, int *elem, int nnode){
   bool quad = nnode > 8;
   if (quad){
     add_cell(build_offset, 10, VTK_QUADRATIC_TETRA);
@@ -239,7 +239,7 @@ __inline void add_tet(bool build_offset, int *elem, int nnode){
 
 
 // ANSYS Tetrahedral style [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-__inline void add_tet10(bool build_offset, int *elem, int nnode){
+static inline void add_tet10(bool build_offset, int *elem, int nnode){
   int i;  // counter
   bool quad = nnode > 4;
   if (quad){
@@ -269,7 +269,7 @@ __inline void add_tet10(bool build_offset, int *elem, int nnode){
 }
 
 
-__inline void add_quad(bool build_offset, int *elem, bool is_quad){
+static inline void add_quad(bool build_offset, int *elem, bool is_quad){
   int i;
   int n_points;
   if (is_quad){
@@ -288,7 +288,7 @@ __inline void add_quad(bool build_offset, int *elem, bool is_quad){
   return;
 }
 
-__inline void add_tri(bool build_offset, int *elem, bool quad){
+void add_tri(bool build_offset, int *elem, bool quad){
   if (quad){
     add_cell(build_offset, 6, VTK_QUADRATIC_TRIANGLE);
   } else {
@@ -310,7 +310,7 @@ __inline void add_tri(bool build_offset, int *elem, bool quad){
 }
 
 
-__inline void add_line(bool build_offset, int *elem, bool quad){
+static inline void add_line(bool build_offset, int *elem, bool quad){
   if (quad){
     add_cell(build_offset, 3, VTK_QUADRATIC_EDGE);
   } else {
@@ -328,7 +328,7 @@ __inline void add_line(bool build_offset, int *elem, bool quad){
 }
 
 
-__inline void add_point(bool build_offset, int *elem){
+static inline void add_point(bool build_offset, int *elem){
   add_cell(build_offset, 1, VTK_VERTEX);
   vtk_data.cells[vtk_data.loc++] = vtk_data.nref[elem[0]];
   return;
@@ -400,6 +400,7 @@ on the edges defined by :
  *
  * nnum : ANSYS Node numbering
  * 
+ * build_offset: Enable, disable populating offset array
  * 
  * Returns (Given as as parameters)
  * -------
@@ -409,11 +410,12 @@ on the edges defined by :
  * 
  * celltypes: VTK cell types
  * 
- * build_offset: Enable, disable populating offset array
+
  * ==========================================================================*/
-int ans_to_vtk(int nelem, int *elem, int *elem_off, int *type_ref, int nnode,
-	       int *nnum, int64_t *offset, int64_t *cells, uint8_t *celltypes,
-	       int build_offset){
+int ans_to_vtk(const int nelem, const int *elem, const int *elem_off,
+	       const int *type_ref, const int nnode, const int* nnum,
+	       int64_t *offset, int64_t *cells, uint8_t *celltypes,
+	       const int build_offset){
   bool is_quad;
   int i;  // counter
   int nnode_elem;  // number of nodes belonging to the element

--- a/pyansys/cython/vtk_support.h
+++ b/pyansys/cython/vtk_support.h
@@ -1,2 +1,3 @@
 #include <stdint.h>
-int ans_to_vtk(int, int*, int*, int*, int, int*, int64_t*, int64_t*, uint8_t*, int);
+int ans_to_vtk(const int, const int*, const int*, const int*, const int, const int*,
+	       int64_t*, int64_t*, uint8_t*, const int);

--- a/setup.py
+++ b/setup.py
@@ -71,10 +71,10 @@ def compilerName():
 compiler = compilerName()
 if compiler == 'unix':
     cmp_arg = ['-O3', '-w']
-    # cmp_arg = ['-fsanitize=address']
+#    if sys.platform == 'darwin':
+#        cmp_arg.append('-flat_namespace')
 else:
     cmp_arg = ['/Ox', '-w']
-    # cmp_arg = ['/RTC']  # debug
 
 
 # Get version from version info
@@ -124,11 +124,6 @@ setup(
     # Build cython modules
     cmdclass={'build_ext': build_ext},
     ext_modules=[
-                 # Extension("pyansys._db_reader",
-                 #           ["pyansys/cython/_db_reader.pyx"],
-                 #           extra_compile_args=cmp_arg,
-                 #           language='c'),
-
                  Extension('pyansys._reader',
                            ['pyansys/cython/_reader.pyx',
                             'pyansys/cython/reader.c',

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -1,10 +1,13 @@
 import glob
 import os
+import sys
 
 import pytest
 import numpy as np
 import pyansys
-from pyansys.mapdl_corba import MapdlCorba
+
+if sys.platform != 'darwin':
+    from pyansys.mapdl_corba import MapdlCorba
 
 path = os.path.dirname(os.path.abspath(__file__))
 
@@ -321,6 +324,7 @@ def test_al(cleared, mapdl):
     assert 'WRITTEN TO FILE' in response
 
 
+@pytest.mark.skipif(not HAS_ANSYS, reason="Requires ANSYS installed")
 def test_logging(mapdl, tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.inp'))
     with pytest.raises(RuntimeError):
@@ -340,6 +344,7 @@ def test_logging(mapdl, tmpdir):
 
 
 # must be at end as this uses a scoped fixture
+@pytest.mark.skipif(not HAS_ANSYS, reason="Requires ANSYS installed")
 def test_exit(mapdl):
     mapdl.exit()
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Darwin on 10.14 and above doesn't like `__inline` and prefers `static inline`.  Performance is the same cross-platform.

Resolves #244.