### PR TITLE
Add array transfer

### DIFF
--- a/docs/ansys_control.rst
+++ b/docs/ansys_control.rst
@@ -1,22 +1,41 @@
 ANSYS APDL Interactive Control
 ==============================
-ANSYS APDL allows for the direct scripting of ANSYS through ANSYS input files.  Unfortunately, APDL relies on an outdated scripting language that is difficult to read and control.  The weaknesses of this language are often compensated by generating APDL scripts using a secondary scripting tool like ``MATLAB`` or ``Python``.  However, this added layer of complexity means that the development feedback loop is quite long as the user must export and run an entire script before determining if it ran correctly or of the results are valid.  This module seeks to rectify that.
+ANSYS APDL allows for the direct scripting of ANSYS through ANSYS
+input files.  Unfortunately, APDL relies on an outdated scripting
+language that is difficult to read and control.  The weaknesses of
+this language are often compensated by generating APDL scripts using a
+secondary scripting tool like ``MATLAB`` or ``Python``.  However, this
+added layer of complexity means that the development feedback loop is
+quite long as the user must export and run an entire script before
+determining if it ran correctly or of the results are valid.  This
+module seeks to rectify that.
 
-The interface control module requires ANSYS to be installed on the system running ``pyansys`` for it to operate.
+The interface control module requires ANSYS to be installed on the
+system running ``pyansys`` for it to operate.
 
 
 Initial Setup and Example
 -------------------------
-The ``ANSYS`` control module within ``pyansys`` creates an instance of an interactive Shell of ``ANSYS`` in the background and sends commands to that shell.  Errors and warnings are processed Pythonically letting the user develop a script real-time without worrying about if it will function correctly when deployed in batch mode.
+The ``ANSYS`` control module within ``pyansys`` creates an instance of
+an interactive Shell of ``ANSYS`` in the background and sends commands
+to that shell.  Errors and warnings are processed Pythonically letting
+the user develop a script real-time without worrying about if it will
+function correctly when deployed in batch mode.
 
-To run, ``pyansys`` needs to know the location of the ANSYS binary.  When running for the first time, ``pyansys`` will request the location of the ANSYS executable.  You can test your installation ``pyansys`` and set it up by running the following in python:
+To run, ``pyansys`` needs to know the location of the ANSYS binary.
+When running for the first time, ``pyansys`` will request the location
+of the ANSYS executable.  You can test your installation ``pyansys``
+and set it up by running the following in python:
 
 .. code:: python
 
     from pyansys import examples
     examples.ansys_cylinder_demo()
 
-Python will automatically attempt to detect your ANSYS binary based on environmental variables.  If it is unable to find a copy of ANSYS, you will be prompted for the location of the ANSYS executable.  Here is a sample input for Linux and Windows:
+Python will automatically attempt to detect your ANSYS binary based on
+environmental variables.  If it is unable to find a copy of ANSYS, you
+will be prompted for the location of the ANSYS executable.  Here is a
+sample input for Linux and Windows:
 
 .. code::
 
@@ -26,7 +45,8 @@ Python will automatically attempt to detect your ANSYS binary based on environme
 
     Enter location of ANSYS executable: C:\Program Files\ANSYS Inc\v170\ANSYS\bin\winx64\ansys170.exe
 
-The settings file is stored locally and do not need to enter it again.  If you need to change the default ansys path, run the following:
+The settings file is stored locally and do not need to enter it again.
+If you need to change the default ansys path, run the following:
 
 .. code:: python
 
@@ -49,7 +69,8 @@ to your current directory with:
     path = os.getcwd()
     mapdl = pyansys.launch_mapdl(run_location=path)
 
-ANSYS is now active and you can send commands to it as if it was just a Python object.
+ANSYS is now active and you can send commands to it as if it was just
+a Python object.
 
 
 Using ANSYS from ``pyansys``
@@ -69,7 +90,9 @@ For example, if we wanted to create a surface using keypoints we could run:
     mapdl.run('L, 4, 1')
     mapdl.run('AL, 1, 2, 3, 4')
 
-ANSYS interactively returns the result of each command and it is stored to the logging module.  Errors are caught immediately.  For example:
+ANSYS interactively returns the result of each command and it is
+stored to the logging module.  Errors are caught immediately.  For
+example:
 
 .. code:: python
 
@@ -289,7 +312,9 @@ Additional examples with more conversion options can be found in the APDL conver
 
 Retreiving Parameters
 ---------------------
-APDL parameters can be retrieved using ``pyansys`` using the ``load_parameters`` method.  For example, after using the ``*GET`` command:
+APDL parameters can be retrieved using ``pyansys`` using the
+``load_parameters`` method.  For example, after using the ``*GET``
+command:
 
 .. code:: python
 
@@ -311,14 +336,25 @@ The parameters are now accessible within the ``MAPDL`` object:
     >>> mapdl.parameters['DEF_Y']
     4.532094298033
 
+
 Caveats and Notes
 -----------------
 
 Command Naming Conventions and Rules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When calling MAPDL commands as functions, each command has been translated from its original MAPDL all CAPS format to a PEP8 compatible format.  For example, ``ESEL`` is now ``esel``.  Additionally, MAPDL commands containing a ``/`` or ``*`` have had those characters removed, unless this causes a conflict with an existing name.  Most notable is ``/SOLU`` which would conflict with ``SOLU``.  Therefore, the ``/SOLU`` has been renamed to ``slashsolu`` to differentiate it from ``solu``.  Out of the 1500 MAPDL commands, about 15 start with ``slash`` and 8 with ``star``.  Check the ``MAPDL Object Methods`` reference below when necessary.
+When calling MAPDL commands as functions, each command has been
+translated from its original MAPDL all CAPS format to a PEP8
+compatible format.  For example, ``ESEL`` is now ``esel``.
+Additionally, MAPDL commands containing a ``/`` or ``*`` have had
+those characters removed, unless this causes a conflict with an
+existing name.  Most notable is ``/SOLU`` which would conflict with
+``SOLU``.  Therefore, the ``/SOLU`` has been renamed to ``slashsolu``
+to differentiate it from ``solu``.  Out of the 1500 MAPDL commands,
+about 15 start with ``slash`` and 8 with ``star``.  Check the ``MAPDL
+Object Methods`` reference below when necessary.
 
-MAPDL commands that normally have an empty space, such as ``ESEL, S, TYPE, , 1`` should include an empty string when called by Python:
+MAPDL commands that normally have an empty space, such as ``ESEL, S,
+TYPE, , 1`` should include an empty string when called by Python:
 
 .. code:: python
 
@@ -337,7 +373,12 @@ None of these restrictions apply to commands run with ``run``:
     mapdl.run('/SOLU')
     mapdl.solve()
 
-Some commands can only be run non-interactively in a script.  ``pyansys`` gets around this restriction by writing the commands to a temporary input file and then reading the input file.  To run a group of commands that must be run non-interactively, set the ``MAPDL`` object to run a series of commands as an input file by using ``non_interactive`` as in this example:
+Some commands can only be run non-interactively in a script.
+``pyansys`` gets around this restriction by writing the commands to a
+temporary input file and then reading the input file.  To run a group
+of commands that must be run non-interactively, set the ``MAPDL``
+object to run a series of commands as an input file by using
+``non_interactive`` as in this example:
 
 .. code:: python
 
@@ -345,7 +386,9 @@ Some commands can only be run non-interactively in a script.  ``pyansys`` gets a
         mapdl.run("*VWRITE,LABEL(1),VALUE(1,1),VALUE(1,2),VALUE(1,3)")
         mapdl.run("(1X,A8,'   ',F10.1,'  ',F10.1,'   ',1F5.3)")
 
-Also note that macros created within pyansys (rather than loaded from a file) do not appear to run correctly.  For example, the macro ``DISP`` created using the ``*CREATE`` command within APDL:
+Also note that macros created within pyansys (rather than loaded from
+a file) do not appear to run correctly.  For example, the macro
+``DISP`` created using the ``*CREATE`` command within APDL:
 
 .. code::
 
@@ -380,7 +423,8 @@ Should be written as:
     DISP(-.05)
     DISP(-.1)
 
-If you have an existing input file with a macro, it can be converted using the ``convert_script`` function:
+If you have an existing input file with a macro, it can be converted
+using the ``convert_script`` function:
 
 .. code:: python
 
@@ -388,13 +432,14 @@ If you have an existing input file with a macro, it can be converted using the `
 
 See the ``vm7.dat`` example in the APDL Conversion Examples page.
 
-..
-   If you're using a blocked macro, it's possible to write a macro using ``with mapdl.non_interactive:``.  See the ``vm8.dat`` example in the APDL Conversion Examples page.
 
 
 Conditional Statements and Loops
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-APDL conditional statements such as ``*IF`` must be either implemented pythonically or using ``with mapdl.non_interactive:``.  See the ``vm8.dat`` example in the APDL Conversion Examples page.  For example:
+APDL conditional statements such as ``*IF`` must be either implemented
+pythonically or using ``with mapdl.non_interactive:``.  See the
+``vm8.dat`` example in the APDL Conversion Examples page.  For
+example:
 
 .. code:: 
 
@@ -751,6 +796,36 @@ This is the result from the script:
     Element size 0.214286: 142496 nodes and maximum vom Mises stress 143.559128
     Element size 0.182143: 211966 nodes and maximum vom Mises stress 143.953430
     Element size 0.150000: 412324 nodes and maximum vom Mises stress 144.275406
+
+
+Sending Arrays to MAPDL
+-----------------------
+You can send ``numpy`` arrays or Python lists directly to MAPDL using
+``load_array``.  This is far more efficient than individually sending
+parameters to MAPDL through python or MAPDL.  It uses ``*VREAD``
+behind the scenes and will be replaced with a faster interface in the
+future.
+
+.. code:: python
+    import pyansys
+    import numpy as np
+    mapdl = pyansys.launch_mapdl()
+    arr = np.random.random((5, 3))
+    mapdl.load_array(arr, 'MYARR')
+
+Verify the data has been propertly loaded to MAPDL by accessing the
+first element.  Note that MAPDL uses fortran (1) based indexing.
+
+.. code:: python
+
+   >>> mapdl.read_float_parameter('MYARR(1, 1)')
+   2020-07-03 21:49:54,387 [INFO] pyansys.mapdl: MYARR(1, 1) = MYARR(1, 1)
+
+   PARAMETER MYARR(1,1) =    0.7960742456
+
+   >>> arr[0]
+   0.7960742456194109
+
 
 
 MAPDL Object Methods

--- a/docs/ansys_examples.rst
+++ b/docs/ansys_examples.rst
@@ -1,6 +1,8 @@
 ANSYS APDL Interactive Control Examples
 =======================================
-These examples are used to demonstrate how to convert an existing ANSYS APDL script to a python ``pyansys`` script.  You could also simply use the built-in ``convert_script`` function within pyansys:
+These examples are used to demonstrate how to convert an existing
+ANSYS APDL script to a python ``pyansys`` script.  You could also
+simply use the built-in ``convert_script`` function within pyansys:
 
 .. code:: python
 
@@ -13,7 +15,8 @@ These examples are used to demonstrate how to convert an existing ANSYS APDL scr
 
 Torsional Load on a Bar using SURF154 Elements
 ----------------------------------------------
-This ANSYS APDL script builds a bar and applies torque to it using SURF154 elements.  This is a static analysis example.
+This ANSYS APDL script builds a bar and applies torque to it using
+SURF154 elements.  This is a static analysis example.
 
 
 Script Initialization
@@ -35,7 +38,8 @@ Beginning of ANSYS script:
     FORCE = 100/RADIUS
     PRESSURE = FORCE/(H_TIP*2*PI*RADIUS)
 
-Corresponding ``pyansys`` script including the initialization of pyansys:
+Corresponding ``pyansys`` script including the initialization of
+pyansys:
 
 .. code:: python
 

--- a/docs/ansys_functions.rst
+++ b/docs/ansys_functions.rst
@@ -1,13 +1,18 @@
 ANSYS Functions
 ===============
-These functions can be called directly from an ``Mapdl`` object.  This is to simplifiy calling ANSYS, especially when inputs are variables within Python.  For example, the following two commands are equivalent:
+MAPDL functions can be called directly from an ``Mapdl`` instance in a
+pythonic manner.  This is to simplify calling ANSYS, especially when
+inputs are variables within Python.  For example, the following two
+commands are equivalent:
 
 .. code:: python
 
     ansys.k(1, 0, 0, 0)
     ansys.run('K, 1, 0, 0, 0')
 
-This approach has some obvious advantages, chiefly that it's a bit easier to script as ``pyansys`` takes care of the string formatting for you.  For example, inputting points from a numpy array:
+This approach has some obvious advantages, chiefly that it's a easier
+to script as ``pyansys`` takes care of the string formatting for you.
+For example, inputting points from a numpy array:
 
 .. code:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,11 @@ Installation through pip::
    loading_km
    loading_emat
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Examples Gallery
+   :hidden:
+
    examples/index
 
 .. toctree::

--- a/examples/01-mapdl-examples/mapdl_3d_beam.py
+++ b/examples/01-mapdl-examples/mapdl_3d_beam.py
@@ -14,7 +14,7 @@ import os
 from pyansys import examples
 import pyansys
 
-os.environ['I_MPI_SHM_LMT'] = 'shm'
+os.environ['I_MPI_SHM_LMT'] = 'shm'  # necessary on ubuntu
 mapdl = pyansys.launch_mapdl(override=True)
 
 mapdl.cdread('db', examples.hexarchivefile)

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,5 +1,5 @@
 .. _ref_examples:
 
-Result MAPDL and Result Reader Examples
-=======================================
+MAPDL and Result Reader Examples
+================================
 Here are a series of examples using MAPDL with ``pyansys``.

--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 41, 6
+version_info = 0, 41, 7
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/cython/_reader.pyx
+++ b/pyansys/cython/_reader.pyx
@@ -21,6 +21,7 @@ cdef extern from "reader.h":
     int read_nblock_from_nwrite(char*, int*, double*, int)
     int read_nblock(char*, int*, double*, int, int*, int, int*)
     int read_eblock(char*, int*, int*, int, int, int*)
+    int write_array_ascii(const char*, const double*, int nvalues);
 
 cdef extern from 'vtk_support.h':
     int ans_to_vtk(const int, const int*, const int*, const int*, const int,
@@ -523,3 +524,8 @@ def read_from_nwrite(filename, int nnodes):
 
     read_nblock_from_nwrite(filename, &nnum[0], &nodes[0, 0], nnodes)
     return np.array(nnum), np.array(nodes)
+
+
+def write_array(filename, const double [::1] arr):
+    cdef int nvalues = arr.size
+    write_array_ascii(filename, &arr[0], nvalues)

--- a/pyansys/cython/_reader.pyx
+++ b/pyansys/cython/_reader.pyx
@@ -18,6 +18,7 @@ cimport numpy as np
 
 
 cdef extern from "reader.h":
+    int read_nblock_from_nwrite(char*, int*, double*, int)
     int read_nblock(char*, int*, double*, int, int*, int, int*)
     int read_eblock(char*, int*, int*, int, int, int*)
 
@@ -513,3 +514,12 @@ def ans_vtk_convert(const int [::1] elem, const int [::1] elem_off,
                               build_offset)
 
     return np.asarray(offset), np.asarray(celltypes), np.asarray(cells[:loc])
+
+
+def read_from_nwrite(filename, int nnodes):
+    """Read the node coordinates from the output from the MAPDL NWRITE command"""
+    cdef int [::1] nnum = np.empty(nnodes, ctypes.c_int)
+    cdef double [:, ::1] nodes = np.empty((nnodes, 3), np.double)
+
+    read_nblock_from_nwrite(filename, &nnum[0], &nodes[0, 0], nnodes)
+    return np.array(nnum), np.array(nodes)

--- a/pyansys/cython/reader.c
+++ b/pyansys/cython/reader.c
@@ -265,7 +265,7 @@ int read_nblock_from_nwrite(const char* filename, int *nnum, double *nodes,
 
   // set to start of the NBLOCK
   const int bufsize = 74;  // One int, 3 floats, two end char max (/r/n)
-  char buffer[bufsize];
+  char buffer[74];
   int i;
 
   for (i=0; i<nnodes; i++){

--- a/pyansys/cython/reader.c
+++ b/pyansys/cython/reader.c
@@ -297,6 +297,8 @@ int read_nblock_from_nwrite(const char* filename, int *nnum, double *nodes,
     nodes[i*3 + 2] = ans_strtod2(&buffer[51], 21);
 
   }
+
+  fclose(stream);
   return 0;
 }
 
@@ -413,4 +415,19 @@ int read_eblock(char *raw, int *elem_off, int *elem, int nelem, int intsz,
   // Return total data read
   elem_off[nelem] = c;
   return c;
+}
+
+// Simply write an array to disk as ASCII
+int write_array_ascii(const char* filename, const double *arr,
+		      const int nvalues){
+  FILE * stream = fopen(filename, "w");
+  int i;
+
+  for (i=0; i<nvalues; i++) {
+    fprintf(stream, "%20.12E\n", arr[i]);
+  }
+
+  fclose(stream);
+
+  return 0;
 }

--- a/pyansys/cython/reader.c
+++ b/pyansys/cython/reader.c
@@ -264,8 +264,8 @@ int read_nblock_from_nwrite(const char* filename, int *nnum, double *nodes,
     }
 
   // set to start of the NBLOCK
-  int bufsize = 9 + 21*3 + 2;  // One int, 3 floats, two end char max (/r/n)
-  char buffer[bufsize];  
+  const int bufsize = 74;  // One int, 3 floats, two end char max (/r/n)
+  char buffer[bufsize];
   int i;
 
   for (i=0; i<nnodes; i++){
@@ -416,6 +416,7 @@ int read_eblock(char *raw, int *elem_off, int *elem, int nelem, int intsz,
   elem_off[nelem] = c;
   return c;
 }
+
 
 // Simply write an array to disk as ASCII
 int write_array_ascii(const char* filename, const double *arr,

--- a/pyansys/cython/reader.c
+++ b/pyansys/cython/reader.c
@@ -125,6 +125,76 @@ __inline int ans_strtod(char *raw, int fltsz, double *arr){
   return 0;  // Return 0 when a number has a been read
 }
 
+static inline double ans_strtod2(char *raw, int fltsz){
+  int i;
+  double sign = 1;
+
+  for (i=0; i<fltsz; i++){
+    if (*raw == '\r' || *raw == '\n'){
+      // value is zero then
+      return 0;
+    }
+    else if (*raw != ' '){  // always skip whitespace
+      break;
+    }
+    raw++;
+  }
+
+  // either a number of a sign
+  if (*raw == '-'){
+    sign = -1;
+    ++raw;
+    ++i;
+  }
+
+  // next value is always a number
+  double val = *raw++ - '0'; i++;
+
+  // next value is always a "."
+  raw++; i++;
+
+  // Read through the rest of the number
+  double k = 0.1;
+  for (; i<fltsz; i++){
+    if (*raw == 'E'){
+      break;
+    }
+    else if (*raw >= '0' && *raw <= '9') {
+      val += (*raw++ - '0') * k;
+      k *= 0.1;
+    }
+  }
+
+  // Might have scientific notation left, for example:
+  // 1.0000000000000E-001
+  int evalue = 0;
+  int esign = 1;
+  if (*raw == 'E'){
+    raw++; // skip "E"
+    // always a sign of some sort
+    if (*raw == '-'){
+      esign = -1;
+    }
+    raw++; i++; i++;  // skip E and sign
+    for (; i<fltsz; i++){
+      // read to whitespace or end of the line
+      if (*raw == ' ' || *raw == '\r' || *raw == '\n'){
+	break;
+      }
+      evalue = evalue*10 + (*raw++ - '0');
+    }
+    val *= pow(10, esign*evalue);
+      
+  }
+
+  // seek through end of float value
+  if (sign == -1){
+    return -val;
+  }
+  return val;
+
+}
+
 
 //=============================================================================
 // reads nblock from ANSYS.  Raw string is from Python reader and file is
@@ -177,6 +247,59 @@ int read_nblock(char *raw, int *nnum, double *nodes, int nnodes, int* intsz,
   return fpos;
 
 }
+
+
+/* Read just the node coordinates from the output from the MAPDL
+ *  NWRITE command
+ * (I8, 6G20.13) to write out NODE,X,Y,Z,THXY,THYZ,THZX
+ */
+int read_nblock_from_nwrite(const char* filename, int *nnum, double *nodes,
+			    int nnodes){
+  FILE * stream = fopen(filename, "r");
+
+  if(stream == NULL)
+    {
+      printf("Error opening file");
+      exit(1);
+    }
+
+  // set to start of the NBLOCK
+  int bufsize = 9 + 21*3 + 2;  // One int, 3 floats, two end char max (/r/n)
+  char buffer[bufsize];  
+  int i;
+
+  for (i=0; i<nnodes; i++){
+    fgets(buffer, bufsize, stream);
+    nnum[i] = fast_atoi(&buffer[0], 9);
+
+    // X
+    if (buffer[9] == '\r' || buffer[9] == '\n'){
+      nodes[i*3 + 0] = 0;
+      nodes[i*3 + 1] = 0;
+      nodes[i*3 + 2] = 0;
+      continue;
+    }
+    nodes[i*3 + 0] = ans_strtod2(&buffer[9], 21);
+
+    // Y
+    if (buffer[30] == '\r' || buffer[30] == '\n'){
+      nodes[i*3 + 1] = 0;
+      nodes[i*3 + 2] = 0;
+      continue;
+    }
+    nodes[i*3 + 1] = ans_strtod2(&buffer[30], 21);
+
+    // Z
+    if (buffer[51] == '\r' || buffer[51] == '\n'){
+      nodes[i*3 + 2] = 0;
+      continue;
+    }
+    nodes[i*3 + 2] = ans_strtod2(&buffer[51], 21);
+
+  }
+  return 0;
+}
+
 
 
 /* ============================================================================

--- a/pyansys/cython/reader.h
+++ b/pyansys/cython/reader.h
@@ -1,3 +1,4 @@
 int read_nblock(char*, int*, double*, int, int*, int, int*);
 int read_eblock(char*, int*, int*, int, int, int*);
 int read_nblock_from_nwrite(char*, int*, double*, int);
+int write_array_ascii(const char*, const double*, int nvalues);

--- a/pyansys/cython/reader.h
+++ b/pyansys/cython/reader.h
@@ -1,2 +1,3 @@
 int read_nblock(char*, int*, double*, int, int*, int, int*);
 int read_eblock(char*, int*, int*, int, int, int*);
+int read_nblock_from_nwrite(char*, int*, double*, int);

--- a/pyansys/geometry.py
+++ b/pyansys/geometry.py
@@ -30,8 +30,8 @@ MESH200_MAP = {0: 2,  # line
 
 class Geometry():
 
-    def __init__(self, nnum, nodes, elem, elem_off, ekey, node_comps={},
-                 elem_comps={}, rdat=[], rnum=[], keyopt={}):
+    def __init__(self, nnum, nodes, elem=None, elem_off=None, ekey=None,
+                 node_comps={}, elem_comps={}, rdat=[], rnum=[], keyopt={}):
         self._etype = None  # internal element type reference
         self._grid = None  # VTK grid
         self._enum = None  # cached element numbering
@@ -44,7 +44,7 @@ class Geometry():
         self._secnum = None  # cached section number
         self._esys = None  # cached element coordinate system
 
-        # must be set by subclass
+        # Set on init
         self._nnum = nnum
         self._nodes = nodes
         self._elem = elem

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -2020,6 +2020,26 @@ class _Mapdl(_MapdlCommands):
         self.solve()
         self.finish()
 
+    def __str__(self):
+        try:
+            stats = self.slashstatus()
+        except:
+            return 'MAPDL exited'
+
+        st = stats.find('*** YOU ARE IN')
+        en = stats.find('INITIAL', st)
+
+        version_str = '\n'.join(stats[st:en].splitlines()[1:])
+        version_str = version_str.split('CUSTOMER')[0].strip() + '\n\n'
+
+        st = stats.find('Current routine')
+        en = stats.find('Active options for this analysis type')
+
+        routine_str = ' ' + stats[st:en].strip()
+
+        pyansys_version_str = '\n\n pyansys version: %s' % pyansys.__version__
+        return version_str + routine_str + pyansys_version_str
+
 
 # TODO: Speed this up with:
 # https://tinodidriksen.com/2011/05/cpp-convert-string-to-double-speed/

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -391,6 +391,24 @@ def test_elements(cleared, mapdl):
 
     assert np.allclose(np.array(mapdl.elements), expected)
 
+@pytest.mark.parametrize("arr", ([1, 2, 3],
+                                 [[1, 2, 3], [1, 2, 3]],
+                                 np.random.random((10)),
+                                 np.random.random((10, 3)),
+                                 np.random.random((10, 3, 3))))
+def test_load_array(cleared, mapdl, arr):
+    mapdl.load_array(arr, 'MYARR')
+    parm, mapdl_arrays = mapdl.load_parameters()
+    assert np.allclose(mapdl_arrays['MYARR'], arr)
+
+
+def test_load_array_err(cleared, mapdl):
+    with pytest.raises(TypeError):
+        mapdl.load_array(['apple'], 'MYARR')
+
+    with pytest.raises(ValueError):
+        mapdl.load_array(np.empty((1, 1, 1, 1)), 'MYARR')
+
 
 # must be at end as this uses a scoped fixture
 @pytest.mark.skipif(not HAS_ANSYS, reason="Requires ANSYS installed")

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -81,6 +81,10 @@ def cleared(mapdl):
     yield
 
 
+def test_str(mapdl):
+    assert 'ANSYS Mechanical' in str(mapdl)
+
+
 ###############################################################################
 # Testing binary reader
 ###############################################################################

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -349,12 +349,10 @@ def test_logging(mapdl, tmpdir):
 
 def test_nodes(cleared, mapdl):
     mapdl.prep7()
-    mapdl.n(1, 0, 0, 0)
-    mapdl.n(11, 10, 0, 0)
-    mapdl.fill(1, 11, 9)
-    expected = np.zeros((11, 3))
-    expected[:, 0] = range(0, 11)
-    assert np.allclose(mapdl.nodes, expected)
+    mapdl.cdread('db', pyansys.examples.sector_archive_file)
+    archive = pyansys.Archive(pyansys.examples.sector_archive_file, parse_vtk=False)
+    mapdl.nwrite('/tmp/ansys/tmp.nodes')
+    assert np.allclose(mapdl.nodes, archive.nodes)
 
 
 def test_nnum(cleared, mapdl):


### PR DESCRIPTION
This PR adds the `load_array` method to `mapdl`.  It's basically an interface to `*VREAD`, but to the user it seamlessly transfers `numpy` arrays or python lists to MAPDL.  In the future this will be replaced by a gRPC interface, but for now this allows `pyansys` to backport `load_array` for earlier versions of MAPDL.

Usage

#### Load_ a 1D numpy array into MAPDL

```python

>>> arr = np.array([10, 20, 30])
>>> mapdl.load_array(arr, 'MYARR')
>>> parm, mapdl_arrays = mapdl.load_parameters()
>>> mapdl_arrays['MYARR']
array([10., 20., 30.])
```

#### Load a 2D numpy array into MAPDL

```python
>>> arr = np.random.random((5, 3))
>>> mapdl.load_array(arr, 'MYARR')
>>> parm, mapdl_arrays = mapdl.load_parameters()
>>> mapdl_arrays['MYARR']
array([[0.39806635, 0.15060953, 0.3990557 ],
       [0.26837768, 0.02033222, 0.15655861],
       [0.46110226, 0.06381489, 0.20068533],
       [0.20122863, 0.5727896 , 0.85636037],
       [0.68126612, 0.67460878, 0.3678797 ]])

```

#### Load a python list into MAPDL

```python
>>> mapdl.load_array([10, -1, 8, 4, 10], 'MYARR')
>>> parm, mapdl_arrays = mapdl.load_parameters()
>>> mapdl_arrays['MYARR']
array([10., -1.,  8.,  4., 10.])
```