### PR TITLE
Fix Archive Scientific Notation

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 43, 3
+version_info = 0, 43, 4
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/archive.py
+++ b/pyansys/archive.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
 
 
-
 class Archive(Mesh):
     """Read a blocked ANSYS archive file.
 

--- a/pyansys/cython/reader.c
+++ b/pyansys/cython/reader.c
@@ -81,7 +81,7 @@ __inline int ans_strtod(char *raw, int fltsz, double *arr){
   // Read through the rest of the number
   double k = 0.1;
   for (; i<fltsz; i++){
-    if (*raw == 'E'){
+    if (*raw == 'e' || *raw == 'E'){  // incredibly, can be lowercase
       break;
     }
     else if (*raw >= '0' && *raw <= '9') {
@@ -94,7 +94,7 @@ __inline int ans_strtod(char *raw, int fltsz, double *arr){
   // 1.0000000000000E-001
   int evalue = 0;
   int esign = 1;
-  if (*raw == 'E'){
+  if (*raw == 'e' || *raw == 'E'){
     raw++; // skip "E"
     // always a sign of some sort
     if (*raw == '-'){
@@ -165,7 +165,7 @@ static inline double ans_strtod2(char *raw, int fltsz){
   // Read through the rest of the number
   k = 0.1;
   for (; i<fltsz; i++){
-    if (*raw == 'E'){
+    if (*raw == 'e' || *raw == 'E'){
       break;
     }
     else if (*raw >= '0' && *raw <= '9') {
@@ -178,7 +178,7 @@ static inline double ans_strtod2(char *raw, int fltsz){
   // 1.0000000000000E-001
   int evalue = 0;
   int esign = 1;
-  if (*raw == 'E'){
+  if (*raw == 'e' || *raw == 'E'){
     raw++; // skip "E"
     // always a sign of some sort
     if (*raw == '-'){

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -1582,7 +1582,7 @@ class _MapdlCore(_MapdlCommands):
         self.finish()
         return out
 
-    def run(self, command, write_to_log=True):
+    def run(self, command, write_to_log=True, **kwargs):
         """Runs APDL command
 
         Parameters
@@ -1594,6 +1594,9 @@ class _MapdlCore(_MapdlCommands):
             Overrides APDL log writing.  Default True.  When set to
             False, will not write command to log, even if APDL
             command logging is enabled.
+
+        kwargs : Optional keyword arguments
+            These keyword arguments are interface specific.
 
         Returns
         -------
@@ -1639,7 +1642,7 @@ class _MapdlCore(_MapdlCommands):
             function = self._redirected_commands[command[:4]]
             return function(command)
 
-        text = self._run(command)
+        text = self._run(command, **kwargs)
         if text:
             self._response = text.strip()
         else:


### PR DESCRIPTION
This PR fixes a bug with a simple but important edge case where the archive file scientific notation contains an `"e"` instead of the standard `"E"`.

Also allows the passing of additional keyword arguments from the `run` command to allow for subclasses of `_MapdlCore` to specify additional kwargs when using `run`.