### PR TITLE
Fix quadratic surface plotting

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 2
+version_info = 0, 44, 3
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/mapdl_geometry.py
+++ b/pyansys/mapdl_geometry.py
@@ -159,11 +159,12 @@ class Geometry():
         groups = [[int(anum), int(nelem)] for anum, nelem in groups]
         self._mapdl.esla('S')
 
-        grid = self._mapdl.mesh._grid
+        grid = self._mapdl.mesh._grid.linear_copy()
         pd = pv.PolyData(grid.points, grid.cells)
 
         pd['ansys_node_num'] = grid['ansys_node_num']
         pd['vtkOriginalPointIds'] = grid['vtkOriginalPointIds']
+        # breakpoint()
         # pd.clean(inplace=True)  # TODO: Consider
 
         # delete all temporary meshes and clean up settings
@@ -188,8 +189,11 @@ class Geometry():
         else:
             entity_num[:] = 0
 
-        grid['entity_num'] = entity_num
-        return grid
+        # grid['entity_num'] = entity_num
+        # return grid
+
+        pd['entity_num'] = entity_num
+        return pd
 
     @property
     def n_volu(self):

--- a/pyansys/mapdl_geometry.py
+++ b/pyansys/mapdl_geometry.py
@@ -164,8 +164,7 @@ class Geometry():
 
         pd['ansys_node_num'] = grid['ansys_node_num']
         pd['vtkOriginalPointIds'] = grid['vtkOriginalPointIds']
-        # breakpoint()
-        # pd.clean(inplace=True)  # TODO: Consider
+        # pd.clean(inplace=True)  # OPTIONAL
 
         # delete all temporary meshes and clean up settings
         with self._mapdl.chain_commands:
@@ -188,9 +187,6 @@ class Geometry():
                 i += nelem
         else:
             entity_num[:] = 0
-
-        # grid['entity_num'] = entity_num
-        # return grid
 
         pd['entity_num'] = entity_num
         return pd


### PR DESCRIPTION
This PR fixes an edge case on Windows where the underlying mesh forces the creation of a quadratic surface plot using MESH200 despite setting KEYOPT1=4.  Fix is to simply force a linear representation of the surface plot.

Commits:
- patch edge case with quadratic surface plot on windows
- remove commented ugrid for surface extraction