### PR TITLE
Add Path Operations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import warnings
 import sphinx_rtd_theme
 
 # -- pyvista configuration ---------------------------------------------------
@@ -20,6 +21,15 @@ if not os.path.exists(pyvista.FIGURE_PATH):
     os.makedirs(pyvista.FIGURE_PATH)
 
 pyvista.BUILDING_GALLERY = True
+
+
+# supress annoying matplotlib bug
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    message='Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.',
+)
+
 
 # -- General configuration ------------------------------------------------
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/examples/02-mapdl-examples/path_operations.py
+++ b/examples/02-mapdl-examples/path_operations.py
@@ -1,0 +1,187 @@
+"""
+.. _ref_plane_stress_concentration:
+
+Path Operations Within pyansys and MAPDL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This tutorial shows how you can use pyansys and MAPDL to interpolate
+along a path for stress.  This shows some advanced features of the
+`pyvista` module to perform the interpolation.
+
+First, start MAPDL as a service and disable all but error messages.
+"""
+# sphinx_gallery_thumbnail_number = 3
+
+import os
+import numpy as np
+import pyvista as pv
+import matplotlib.pyplot as plt
+
+import pyansys
+
+os.environ['I_MPI_SHM_LMT'] = 'shm'  # necessary on Ubuntu
+mapdl = pyansys.launch_mapdl(loglevel='ERROR')
+
+###############################################################################
+# MAPDL: Solve a Beam with a Non-Uniform Load
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Create a beam, apply a load, and solve for the static solution.
+
+# beam dimensions
+_width = 0.5
+_height = 2
+_length = 10
+
+# simple 3D beam
+mapdl.clear()
+mapdl.prep7()
+mapdl.mp("EX", 1, 70000)
+mapdl.mp("NUXY", 1, 0.3)
+mapdl.csys(0)
+mapdl.blc4(0, 0, 0.5, 2, _length)
+mapdl.et(1, "SOLID186")
+mapdl.type(1)
+mapdl.keyopt(1, 2, 1)
+mapdl.desize("", 100)
+
+mapdl.vmesh("ALL")
+# mapdl.eplot()
+
+# fixed constraint
+mapdl.nsel("s", "loc", "z", 0)
+mapdl.d("all", "ux", 0)
+mapdl.d("all", "uy", 0)
+mapdl.d("all", "uz", 0)
+
+# arbitrary non-uniform load
+mapdl.nsel("s", "loc", "z", _length)
+mapdl.f("all", "fz", 1)
+mapdl.f("all", "fy", 10)
+mapdl.nsel("r", "loc", "y", 0)
+mapdl.f("all", "fx", 10)
+mapdl.run("alls")
+mapdl.run("/solu")
+sol_output = mapdl.solve()
+
+# plot the normalized global displacement
+mapdl.result.plot_nodal_displacement(0, lighting=False, show_edges=True)
+
+# same as:
+# mapdl.post_processing.plot_nodal_displacement(lighting=False, show_edges=True)
+
+###############################################################################
+# Post-Processing - MAPDL Path Operation
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Compute the stress along a path within MAPDL and convert the result
+# to a numpy array
+
+mapdl.post1()
+mapdl.set(1, 1)
+mapdl.plesol("s", "int")
+
+# path definition
+pl_end = (0.5*_width, _height, 0.5*_length)
+pl_start = (0.5*_width, 0, 0.5*_length)
+
+mapdl.run("_width = %f" % _width)
+mapdl.run("_height = %f" % _height)
+mapdl.run("_length = %f" % _length)
+
+mapdl.run("pl_end = node(0.5*_width, _height, 0.5*_length)")
+mapdl.run("pl_start = node(0.5*_width, 0, 0.5*_length)")
+mapdl.path("my_path", 2, ndiv=100)
+mapdl.ppath(1, "pl_start")
+mapdl.ppath(2, "pl_end")
+
+# mapping components of interest to path.
+mapdl.pdef("Sx_my_path", "s", "x")
+mapdl.pdef("Sy_my_path", "s", "y")
+mapdl.pdef("Sz_my_path", "s", "z")
+mapdl.pdef("Sxy_my_path", "s", "xy")
+mapdl.pdef("Syz_my_path", "s", "yz")
+mapdl.pdef("Szx_my_path", "s", "xz")
+
+# Extract the path results from MAPDL and send to a numpy array
+nsigfig = 10
+mapdl.header('OFF', 'OFF', 'OFF', 'OFF', 'OFF', 'OFF')
+mapdl.format('', 'E', nsigfig + 9, nsigfig)
+mapdl.page(1E9, '', -1, 240)
+
+path_out = mapdl.prpath("Sx_my_path", "Sy_my_path", "Sz_my_path",
+                        "Sxy_my_path", "Syz_my_path", "Szx_my_path")
+table = np.genfromtxt(path_out.splitlines()[1:])
+print('Numpy Array from MAPDL Shape:', table.shape)
+
+###############################################################################
+# Comparing with Path Operation Within `pyvista`
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The same path operation can be performed within `pyvista` by saving
+# the resulting stress and storing within the underlying ``UnstructuredGrid``
+#
+# Take note that there is slight piece-wise behavior in both MAPDL's
+# and VTK's interpoltion methods (both of which result in nearly
+# identical interpolations).  The underlying algorthim of VTK is:
+#
+# ::
+#
+#   The `vtkProbeFilter`, once it finds the cell containing a query
+#   point, uses the cell's interpolation functions to perform the
+#   interpolate / compute the point attributes.
+
+# same thing in pyvista
+rst = mapdl.result
+nnum, stress = rst.nodal_stress(0)
+
+# get SYZ stress
+stress_yz = stress[:, 5]
+
+# Assign the YZ stress to the underlying grid within the result instance.
+# For this example, NAN values must be replaced with 0 for the
+# interpolation to succeed
+rst.grid['Stress YZ'] = stress_yz
+mask = np.isnan(stress[:, 0])
+rst.grid['Stress YZ'][mask] = 0
+
+# Create a line and sample over it
+line = pv.Line(pl_start, pl_end, resolution=100)
+out = line.sample(rst.grid)
+
+# Note: We could have used a spline (or really, any dataset), and
+# interpolated over it instead of a simple line.
+
+# plot the interpolated stress from VTK and MAPDL
+plt.plot(out.points[:, 1], out['Stress YZ'], 'x', label='Stress vtk')
+plt.plot(table[:, 0], table[:, 6], label='Stress MAPDL')
+plt.legend()
+plt.xlabel('Y Position (in.)')
+plt.ylabel('Stress YZ (psi)')
+plt.show()
+
+
+###############################################################################
+# 2D Slice Interpolation
+# ~~~~~~~~~~~~~~~~~~~~~~
+# Take a 2D slice along the beam and plot it alongside the stress at
+# the line.
+#
+# Note that this slice occurs between the edge nodes of this beam,
+# necessitating interpolation as stress/strain is (in general)
+# extrapolated to the edge nodes of ANSYS FEMs.
+
+stress_slice = rst.grid.slice('z', pl_start)
+
+# can plot this individually
+# stress_slice.plot(scalars=stress_slice['Stress YZ'], stitle='Stress YZ')
+
+# good camera position (determined manually using pl.camera_position)
+cpos = [(3.2, 4, 8),
+        (0.25, 1.0, 5.0),
+        (0.0, 0.0, 1.0)]
+
+rng = [rst.grid['Stress YZ'].min(), rst.grid['Stress YZ'].max()]
+pl = pv.Plotter()
+pl.add_mesh(out, scalars=out['Stress YZ'], line_width=10)
+pl.add_mesh(stress_slice, scalars='Stress YZ', opacity=0.25)
+pl.add_mesh(rst.grid, color='w', style='wireframe')
+pl.camera_position = cpos
+pl.show()

--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 4
+version_info = 0, 44, 5
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -1104,8 +1104,7 @@ class _MapdlCore(_MapdlCommands):
             result_path = self._result_file
 
         if result_path is None:
-            breakpoint()
-            raise RuntimeError('Unable to generate result path')
+            raise FileNotFoundError('No result file(s) at %s' % self.directory)
         if not os.path.isfile(result_path):
             raise FileNotFoundError('No results found at %s' % result_path)
 

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -130,7 +130,7 @@ class _MapdlCore(_MapdlCommands):
         self._redirected_commands = {'*LIS': self._list}
 
         if log_apdl:
-            filename = os.path.join(self.path, 'log.inp')
+            filename = os.path.join(self.directory, 'log.inp')
             self.open_apdl_log(filename, mode=log_apdl)
 
         self._post = PostProcessing(self)
@@ -364,8 +364,8 @@ class _MapdlCore(_MapdlCommands):
         """Write entire archive to ASCII and read it in as a ``pyansys.Archive``"""
         if self._archive_cache is None:
             # write database to an archive file
-            arch_filename = os.path.join(self.path, '_tmp.cdb')
-            nblock_filename = os.path.join(self.path, 'nblock.cdb')
+            arch_filename = os.path.join(self.directory, '_tmp.cdb')
+            nblock_filename = os.path.join(self.directory, 'nblock.cdb')
             # must have all nodes elements are using selected
             with self.chain_commands:
                 self.cm('__NODE__', 'NODE')
@@ -459,7 +459,7 @@ class _MapdlCore(_MapdlCommands):
     @run_as_prep7
     def _generate_iges(self):
         """Save IGES geometry representation to disk"""
-        filename = os.path.join(self.path, '_tmp.iges')
+        filename = os.path.join(self.directory, '_tmp.iges')
         self.igesout(filename, att=1)
         return filename
 
@@ -850,7 +850,7 @@ class _MapdlCore(_MapdlCommands):
     def _list(self, command):
         """ Replaces *LIST command """
         items = command.split(',')
-        filename = os.path.join(self.path, '.'.join(items[1:]))
+        filename = os.path.join(self.directory, '.'.join(items[1:]))
         if os.path.isfile(filename):
             self._response = open(filename).read()
             self._log.info(self._response)
@@ -1127,8 +1127,8 @@ class _MapdlCore(_MapdlCommands):
             ext = ''
 
         if ext == '':
-            rth_file = os.path.join(self.path, '%s.%s' % (filename, 'rth'))
-            rst_file = os.path.join(self.path, '%s.%s' % (filename, 'rst'))
+            rth_file = os.path.join(self.directory, '%s.%s' % (filename, 'rth'))
+            rst_file = os.path.join(self.directory, '%s.%s' % (filename, 'rst'))
 
             if os.path.isfile(rth_file) and os.path.isfile(rst_file):
                 return last_created([rth_file, rst_file])
@@ -1137,7 +1137,7 @@ class _MapdlCore(_MapdlCommands):
             elif os.path.isfile(rst_file):
                 return rst_file
         else:
-            filename = os.path.join(self.path, '%s.%s' % (filename, ext))
+            filename = os.path.join(self.directory, '%s.%s' % (filename, ext))
             if os.path.isfile(filename):
                 return filename
 
@@ -1155,8 +1155,8 @@ class _MapdlCore(_MapdlCommands):
         if filename[-1].isnumeric():
             filename += '_'
 
-        rth_file = os.path.join(self.path, '%s0.%s' % (filename, 'rth'))
-        rst_file = os.path.join(self.path, '%s0.%s' % (filename, 'rst'))
+        rth_file = os.path.join(self.directory, '%s0.%s' % (filename, 'rth'))
+        rst_file = os.path.join(self.directory, '%s0.%s' % (filename, 'rst'))
         if os.path.isfile(rth_file) and os.path.isfile(rst_file):
             return last_created([rth_file, rst_file])
         elif os.path.isfile(rth_file):
@@ -1851,19 +1851,20 @@ class _MapdlCore(_MapdlCommands):
 
     @property
     @supress_logging
-    def path(self):
+    def directory(self):
         """Current MAPDL directory
 
         Examples
         --------
-        Path on Linux
+        Directory on Linux
 
-        >>> mapdl.path
+        >>> mapdl.directory
         '/tmp/ansys'
 
-        Path on Windows
+        Directory on Windows
 
-        >>> mapdl.path
+        >>> mapdl.directory
+        'C:/temp_directory/'
 
         """
         # always attempt to cache the path
@@ -1876,7 +1877,7 @@ class _MapdlCore(_MapdlCommands):
     @property
     def _lockfile(self):
         """lockfile path"""
-        path = self.path
+        path = self.directory
         if path is not None:
             return os.path.join(path, self.jobname + '.lock').replace('\\', '/')
 
@@ -2023,7 +2024,7 @@ class _MapdlCore(_MapdlCommands):
 
     def _screenshot_path(self):
         """Return last filename based on the current jobname"""
-        filenames = glob.glob(os.path.join(self.path, '%s*.png' % self.jobname))
+        filenames = glob.glob(os.path.join(self.directory, '%s*.png' % self.jobname))
         filenames.sort()
         return filenames[-1]
 

--- a/pyansys/mapdl_corba.py
+++ b/pyansys/mapdl_corba.py
@@ -177,7 +177,7 @@ class MapdlCorba(_MapdlCore):
 
     @property
     def _broadcast_file(self):
-        return os.path.join(self.path, 'mapdl_broadcasts.txt')
+        return os.path.join(self.directory, 'mapdl_broadcasts.txt')
 
     @threaded
     def _start_broadcast_logger(self, update_rate=1.0):
@@ -216,7 +216,7 @@ class MapdlCorba(_MapdlCore):
     def exit(self, close_log=True, timeout=3):
         """Exit MAPDL process"""
         # cache final path and lockfile before exiting
-        path = self.path
+        path = self.directory
         lockfile = self._lockfile
 
         self._log.debug('Exiting ANSYS')
@@ -295,7 +295,7 @@ class MapdlCorba(_MapdlCore):
 
                 if filename:
                     if os.path.basename(filename) == filename:
-                        filename = os.path.join(self.path, filename)
+                        filename = os.path.join(self.directory, filename)
                     self._output = filename
                     if len(items) == 5:
                         if items[4].lower().strip() == 'append':

--- a/pyansys/parameters.py
+++ b/pyansys/parameters.py
@@ -423,7 +423,7 @@ class Parameters():
 
     def _write_numpy_array(self, filename, arr):
         """Write a numpy array to disk"""
-        filename = os.path.join(self._mapdl.path, filename)
+        filename = os.path.join(self._mapdl.directory, filename)
         if arr.dtype != np.double:
             arr = arr.astype(np.double)
         pyansys._reader.write_array(filename.encode(), arr.ravel('F'))

--- a/tests/test_dist_rst.py
+++ b/tests/test_dist_rst.py
@@ -86,9 +86,9 @@ def test_not_a_dis_rst(tmpdir):
 
 @skip_no_ansys
 def test_not_all_found(thermal_solution, mapdl, tmpdir):
-    filename = os.path.join(mapdl.path, 'file0.rth')
+    filename = os.path.join(mapdl.directory, 'file0.rth')
 
-    tmp_file = os.path.join(mapdl.path, 'tmp0.rth')
+    tmp_file = os.path.join(mapdl.directory, 'tmp0.rth')
     shutil.copy(filename, tmp_file)
     with pytest.raises(FileNotFoundError):
         dist_rst = pyansys.read_binary(tmp_file)
@@ -97,7 +97,7 @@ def test_not_all_found(thermal_solution, mapdl, tmpdir):
 @skip_no_ansys
 def test_temperature(thermal_solution, mapdl, tmpdir):
     ans_temp = mapdl.post_processing.nodal_temperature
-    dist_rst = pyansys.read_binary(os.path.join(mapdl.path, 'file0.rth'))
+    dist_rst = pyansys.read_binary(os.path.join(mapdl.directory, 'file0.rth'))
 
     # normal result should match
     rst = mapdl.result  # normally not distributed
@@ -112,7 +112,7 @@ def test_temperature(thermal_solution, mapdl, tmpdir):
 
 @skip_no_ansys
 def test_plot_temperature(thermal_solution, mapdl):
-    dist_rst = pyansys.read_binary(os.path.join(mapdl.path, 'file0.rth'))
+    dist_rst = pyansys.read_binary(os.path.join(mapdl.directory, 'file0.rth'))
     cpos = dist_rst.plot_nodal_temperature(0)
     assert isinstance(cpos, CameraPosition)
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -89,7 +89,7 @@ def test_output(cleared, mapdl):
     comment = 'Testing...'
     resp = mapdl.com(comment)
     mapdl.output()
-    output = open(os.path.join(mapdl.path, tmp_file)).read()
+    output = open(os.path.join(mapdl.directory, tmp_file)).read()
     assert comment in output
 
 


### PR DESCRIPTION
As it turns out, `path` is a MAPDL command (interpolate along path), and the Mapdl class has been using it as the path variable.  This PR refactors `path` to `directory` and adds a path operation example in response to issue #272.

<details>
  <summary>Commit Summary</summary>
- path --> directory
- add path operation example
- actually add path operation example
- version bump to 0.44.5
</details>
