### PR TITLE
Fix single cyclic result with no complex content bug

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 5
+version_info = 0, 44, 6
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/cyclic_reader.py
+++ b/pyansys/cyclic_reader.py
@@ -112,6 +112,9 @@ class CyclicResult(Result):
         if self._is_repeated_mode.size == 2 and self._is_repeated_mode.all():
             self._repeated_index = np.array([1, 0])
             return
+        elif self._is_repeated_mode.size == 1:  # edge case single result
+            self._is_repeated_mode = np.array([False])
+            return
 
         self._repeated_index = np.empty(self._is_repeated_mode.size, np.int)
         self._repeated_index[:] = -1

--- a/pyansys/rst.py
+++ b/pyansys/rst.py
@@ -1223,10 +1223,6 @@ class Result(AnsysBinary):
             new_sidx = np.argsort(unsort_nnum)
             nnum = unsort_nnum[new_sidx]
             result = result[new_sidx]
-
-            # these are the associated nodal locations
-            # sidx_inv = np.argsort(self._sidx)
-            # nodes = self._mesh['nodes'][sidx_inv][sidx][:, :3]
         else:
             nnum = self._neqv[self._sidx]
             result = result.take(self._sidx, 0)
@@ -1238,10 +1234,7 @@ class Result(AnsysBinary):
 
         # check for invalid values (mapdl writes invalid values as 2*100)
         result[result == 2**100] = 0
-        # if result.shape[1] == 1:
-        #     result = result.ravel()
         return nnum, result
-
 
     @wraps(nodal_solution)
     def nodal_displacement(self, *args, **kwargs):


### PR DESCRIPTION
This PR fixes a small bug where pyansys improperly reports complex content of a non-complex mode when the result file contains only one result. 
