### PR TITLE
Strip Component Names

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 7
+version_info = 0, 44, 8
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/cython/_reader.pyx
+++ b/pyansys/cython/_reader.pyx
@@ -316,7 +316,7 @@ def read(filename, read_parameters=False, debug=False):
                 # Get Component name
                 ind1 = line.find(b',') + 1
                 ind2 = line.find(b',', ind1)
-                comname = line[ind1:ind2].decode()
+                comname = line[ind1:ind2].decode().strip()
 
                 # Get number of items
                 ncomp = int(line[line.rfind(b',') + 1:line.find(b'!')])


### PR DESCRIPTION
This PR corrects a bug where read in component names that have not had their component names striped.  This bug results in extra characters and deviates from the established behavior in `pyansys<=0.44.0` prior to the mesh/reader refactor.
