### PR TITLE
use read_record_stream when storing elements

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 14
+version_info = 0, 44, 15
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/cython/_binary_reader.pyx
+++ b/pyansys/cython/_binary_reader.pyx
@@ -271,10 +271,8 @@ def load_elements(filename, int64_t loc, int nelem, int64_t [::1] e_disp_table):
     cdef int prec_flag, type_flag, size, bufsize
     cdef void* c_ptr
 
-    cdef bytes py_bytes = filename.encode()
-    cdef char* c_filename = py_bytes
-    cdef int* element
-    cdef short* s_element
+    cdef bytes c_filename = filename.encode()
+    cdef ifstream* binfile = new ifstream(<char*>c_filename, binary)
 
     cdef int val, nread
     cdef int64_t elem_loc
@@ -282,26 +280,26 @@ def load_elements(filename, int64_t loc, int nelem, int64_t [::1] e_disp_table):
     # elem connectivity and info (10 fields + maximum of 20 nodes per element)
     cdef int [::1] elem = np.empty(nelem*30, np.int32)
     cdef int [::1] elem_off = np.empty(nelem + 1, np.int32)
+    cdef char [512] tmp_buf
 
     cdef int c = 0  # cell position counter
     for i in range(nelem):
         # load element
         elem_loc = loc + e_disp_table[i]
-        c_ptr = read_record(c_filename, elem_loc, &prec_flag, &type_flag,
-                            &size, &bufsize)
+        read_record_stream(binfile, elem_loc, <void*>tmp_buf,
+                           &prec_flag, &type_flag, &size)
 
         # start of the element
         elem_off[i] = c
 
+        # always cast 
         # read in entire element
         if prec_flag:
-            s_element = <short*>c_ptr
             for j in range(size):
-                elem[c + j] = s_element[j]
+                elem[c + j] = <int>(<short*>tmp_buf)[j]
         else:
-            element = <int*>c_ptr
             for j in range(size):
-                elem[c + j] = element[j]
+                elem[c + j] = (<int*>tmp_buf)[j]
         c += size
 
     # add final position here for parser to know the size of the last element

--- a/pyansys/cython/_binary_reader.pyx
+++ b/pyansys/cython/_binary_reader.pyx
@@ -282,41 +282,25 @@ def load_elements(filename, int64_t loc, int nelem, int64_t [::1] e_disp_table):
     cdef int [::1] elem_off = np.empty(nelem + 1, np.int32)
     cdef char [512] tmp_buf
 
-    # in the unlikely case where elements are stored as short
     cdef int c = 0  # cell position counter
-    elem_loc = loc + e_disp_table[0]
-    read_record_stream(binfile, elem_loc, <void*>(&elem[0]),
-                       &prec_flag, &type_flag, &size)
+    for i in range(nelem):
+        # load element
+        elem_loc = loc + e_disp_table[i]
+        read_record_stream(binfile, elem_loc, <void*>tmp_buf,
+                           &prec_flag, &type_flag, &size)
 
-    if prec_flag:
-        for i in range(nelem):
-            # load element
-            elem_loc = loc + e_disp_table[i]
-            read_record_stream(binfile, elem_loc, <void*>tmp_buf,
-                               &prec_flag, &type_flag, &size)
+        # start of the element
+        elem_off[i] = c
 
-            # start of the element
-            elem_off[i] = c
-
-            # always cast 
-            # read in entire element
-            if prec_flag:
-                for j in range(size):
-                    elem[c + j] = <int>(<short*>tmp_buf)[j]
-            else:
-                for j in range(size):
-                    elem[c + j] = (<int*>tmp_buf)[j]
-            c += size
-    else:
-        for i in range(nelem):
-            # load element
-            elem_loc = loc + e_disp_table[i]
-            read_record_stream(binfile, elem_loc, <void*>(&elem[c]),
-                               &prec_flag, &type_flag, &size)
-
-            # start of the element
-            elem_off[i] = c
-            c += size
+        # always cast in the unlikely case where elements are stored
+        # as short
+        if prec_flag:
+            for j in range(size):
+                elem[c + j] = <int>(<short*>tmp_buf)[j]
+        else:
+            for j in range(size):
+                elem[c + j] = (<int*>tmp_buf)[j]
+        c += size
 
     # add final position here for parser to know the size of the last element
     elem_off[nelem] = c


### PR DESCRIPTION
This PR resolves #305 where there was a bug that opened/closed the result file when reading each element's connectivity.  Framework was already in place to open once with `read_record_stream`.  This PR also removes an extra array copying step when reading in `int` values from the result file (written by default).

Bumps version to ``pyansys==0.44.15``