### PR TITLE
Permit *.dat as Archive Objects

### DIFF
--- a/pyansys/archive.py
+++ b/pyansys/archive.py
@@ -24,9 +24,12 @@ log.setLevel('CRITICAL')
 
 
 class Archive(Mesh):
-    """Read a blocked ANSYS archive file.
+    """Read a blocked ANSYS archive file or input file.
 
     Reads a blocked CDB file and optionally parses it to a vtk grid.
+    This can be used to read in files written from MAPDL using the
+    ``CDWRITE`` command or input files (``*.dat) files written from
+    ANSYS Workbench.
 
     Write the archive file using ``CDWRITE, DB, archive.cdb``
 
@@ -58,6 +61,13 @@ class Archive(Mesh):
         as empty (null) elements.  Useful for debug or tracking
         element numbers.  Default False.
 
+    verbose : bool, optional
+        Print out each step when reading the archive file.  Used for
+        debug purposes and defaults to ``False``.
+
+    name : str, optional
+        Internally used parameter used to have a custom ``__repr__``.
+
     Examples
     --------
     >>> import pyansys
@@ -80,6 +90,18 @@ class Archive(Mesh):
            [0.75, 0.5 , 3.5 ],
            [0.75, 0.5 , 4.  ],
            [0.75, 0.5 , 4.5 ]])
+
+    Read an ANSYS workbench input file
+
+    >>> my_archive = pyansys.Archive('C:\\Users\\jerry\\stuff.dat')
+
+    Notes
+    -----
+    This class only reads EBLOCK records with SOLID records.  For
+    example, the record ``EBLOCK,19,SOLID,,3588`` will be read, but
+    ``EBLOCK,10,,,3588`` will not be read.  Generally, MAPDL will only
+    write SOLID records and Mechanical Workbench may write SOLID
+    records.  These additional records will be ignored.
     """
 
     def __init__(self, filename, read_parameters=False,
@@ -198,7 +220,12 @@ class Archive(Mesh):
 
     @wraps(pv.plot)
     def plot(self, *args, **kwargs):
-        """Plot the ANSYS archive file"""
+        """Plot the mesh"""
+        if self._grid is None:  # pragma: no cover
+            raise AttributeError('Archive must be parsed as a vtk grid.\n'
+                                 'Set `parse_vtk=True`')
+        kwargs.setdefault('color', 'w')
+        kwargs.setdefault('show_edges', True)
         self.grid.plot(*args, **kwargs)
 
 

--- a/pyansys/cython/reader.c
+++ b/pyansys/cython/reader.c
@@ -208,6 +208,11 @@ static inline double ans_strtod2(char *raw, int fltsz){
 //=============================================================================
 // reads nblock from ANSYS.  Raw string is from Python reader and file is
 // positioned at the start of the data of NBLOCK
+//
+// Returns
+// -------
+// nnodes_read : int
+//     Number of nodes read.
 //=============================================================================
 int read_nblock(char *raw, int *nnum, double *nodes, int nnodes, int* intsz,
 		int fltsz, int *n){
@@ -218,6 +223,13 @@ int read_nblock(char *raw, int *nnum, double *nodes, int nnodes, int* intsz,
   int i, j, i_val, eol;
 
   for (i=0; i<nnodes; i++){
+
+    // It's possible that less nodes are written to the record than
+    // indicated.  In this case the line starts with a -1
+    if (raw[0] == '-'){
+      break;
+    }
+
     i_val = fast_atoi(raw, intsz[0]);
     /* printf("%d", i_val); */
     nnum[i] = i_val;
@@ -252,8 +264,10 @@ int read_nblock(char *raw, int *nnum, double *nodes, int nnodes, int* intsz,
   }
 
   // return file position
-  int fpos = len_orig - strlen(raw) + n[0];
-  return fpos;
+  /* int fpos = len_orig - strlen(raw) + n[0]; */
+  /* return fpos; */
+  n[0] += len_orig - strlen(raw);
+  return i;
 
 }
 
@@ -405,6 +419,7 @@ int read_eblock(char *raw, int *elem_off, int *elem, int nelem, int intsz,
     
     // Field 11: Element number
     elem[c++] = fast_atoi(raw, intsz); raw += intsz;
+    /* printf("reading element %d\n", elem[c - 1]); */
 
     // Need an additional value for consitency with other formats
     elem[c++] = 0;

--- a/pyansys/mesh.py
+++ b/pyansys/mesh.py
@@ -150,10 +150,10 @@ class Mesh():
             # cells[cells >= nodes.shape[0]] = 0  # fails when n_nodes < 20
 
         if VTK9:
-            grid = pv.UnstructuredGrid(cells, celltypes, nodes, deep=False)
+            grid = pv.UnstructuredGrid(cells, celltypes, nodes, deep=True)
         else:
             grid = pv.UnstructuredGrid(offset, cells, celltypes, nodes,
-                                       deep=False)
+                                       deep=True)
 
         # Store original ANSYS element and node information
         grid.point_arrays['ansys_node_num'] = nnum
@@ -611,6 +611,7 @@ def fix_missing_midside(cells, nodes, celltypes, offset, angles, nnum):
 
     nodes_new = np.empty((nnodes + nextra, 3))
     nodes_new[:nnodes] = nodes
+    nodes_new[nnodes:] = 0  # otherwise, segfault disaster
 
     # Set new midside nodes directly between their edge nodes
     temp_nodes = nodes_new.copy()


### PR DESCRIPTION
## Overview

This PR patches the ``pyansys.Archive`` class to allow for the reading of *.dat files.  Given that the reader/writer for MAPDL is different than the one used for ANSYS mechanical workbench, several allowances are made in the reader to allow for the variation in syntax and capitalization.

### MISC Fix
There is an edge case when reading archive files with missing mid-side nodes where NANs are stored within points causing unintended side-effects for any downstream applications.

#### Notes
Update version to ``pyansys==0.44.15``
