### PR TITLE
fix edge case with missing mid-side nodes

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 16
+version_info = 0, 44, 17
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/cython/_reader.pyx
+++ b/pyansys/cython/_reader.pyx
@@ -450,7 +450,7 @@ def read(filename, read_parameters=False, debug=False):
         elem_sz = 0
 
     return {'rnum': np.asarray(rnum),
-            'rdat': np.asarray(rdat),
+            'rdat': rdat,
             'ekey': np.asarray(elem_type, ctypes.c_int),
             'nnum': np.asarray(nnum),
             'nodes': np.asarray(nodes),

--- a/pyansys/cython/reader.c
+++ b/pyansys/cython/reader.c
@@ -431,6 +431,20 @@ int read_eblock(char *raw, int *elem_off, int *elem, int nelem, int intsz,
       while (raw[0] == '\r' || raw[0] == '\n' ) ++raw;
       elem[c++] = fast_atoi(raw, intsz); raw += intsz;
     }
+
+    // Edge case where missing midside nodes are not written (because
+    // MAPDL refuse to write zeros at the end of a line)
+    if (nnode < 20 && nnode > 10){
+      for (j=nnode; j<20; j++){
+        elem[c++] = 0;
+      }
+    }
+    /* else if (nnode < 8 && nnode > 4){ */
+    /*   for (j=nnode; j<8; j++){ */
+    /*     elem[c++] = 0; */
+    /*   } */
+    /* } */
+
   }
 
   // update file position


### PR DESCRIPTION
Patches an edge case where unwritten mid-side nodes are not written in a MAPDL EBLOCK.

Bumps version to ``0.44.17``
