### PR TITLE
fix missing is_quad specification

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 17
+version_info = 0, 44, 18
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/cython/vtk_support.c
+++ b/pyansys/cython/vtk_support.c
@@ -480,6 +480,7 @@ int ans_to_vtk(const int nelem, const int *elem, const int *elem_off,
       /* printf("nnode_elem %d: \n", nnode_elem); */
       if (nnode_elem == 3){
 	/* printf(" subtype tri\n"); */
+        is_quad = false;
 	add_tri(build_offset, &elem[off], is_quad);
       } else if (elem[off + 2] == elem[off + 3]){
 	/* printf(" subtype tri\n"); */

--- a/pyansys/cython/vtk_support.c
+++ b/pyansys/cython/vtk_support.c
@@ -480,8 +480,7 @@ int ans_to_vtk(const int nelem, const int *elem, const int *elem_off,
       /* printf("nnode_elem %d: \n", nnode_elem); */
       if (nnode_elem == 3){
 	/* printf(" subtype tri\n"); */
-        is_quad = false;
-	add_tri(build_offset, &elem[off], is_quad);
+	add_tri(build_offset, &elem[off], false);
       } else if (elem[off + 2] == elem[off + 3]){
 	/* printf(" subtype tri\n"); */
 	is_quad = nnode_elem > 4;


### PR DESCRIPTION
Quick patch for quadratic shell element parsing due to forgetting to set the `is_quad` parameter when building shell elements within `vtk_support`.
