### PR TITLE
Update for v211 (2021R1)

### DIFF
--- a/pyansys/_rst_keys.py
+++ b/pyansys/_rst_keys.py
@@ -1,57 +1,76 @@
-"""Various header keys for the result file"""
+"""Various header keys for the result file
 
-geometry_header_keys = ['__unused',  # position not used
-                        'maxety',
-                        'maxrl',
-                        'nnod',
-                        'nelm',
-                        'maxcsy',
-                        'ptrETY',
-                        'ptrREL',
-                        'ptrLOC',
-                        'ptrCSY',
-                        'ptrEID',
-                        'maxsec',
-                        'secsiz',
-                        'nummat',
-                        'matsiz',
-                        'ptrMAS',
-                        'csysiz',
-                        'elmsiz',
-                        'etysiz',
-                        'rlsiz',
-                        'ptrETYl',
-                        'ptrETYh',
-                        'ptrRELl',
-                        'ptrRELh',
-                        'ptrCSYl',
-                        'ptrCSYh',
-                        'ptrLOCl',
-                        'ptrLOCh',
-                        'ptrEIDl',
-                        'ptrEIDh',
-                        'ptrMASl',
-                        'ptrMASh',
-                        'ptrSECl',
-                        'ptrSECh',
-                        'ptrMATl',
-                        'ptrMATh',
-                        'ptrCNTl',
-                        'ptrCNTh',
-                        'ptrNODl',
-                        'ptrNODh',
-                        'ptrELMl',
-                        'ptrELMh',
-                        'Glblenb',
-                        'ptrGNODl',
-                        'ptrGNODh',
-                        'maxn',
-                        'NodesUpd',
-                        'lenbac',
-                        'maxcomp',
-                        'compsiz',
-                        'ptrCOMPl',
-                        'ptrCOMPh']
+/usr/ansys_inc/v150/ansys/customize/include/fdresu.inc
+
+"""
+
+geometry_header_keys = ['__unused',  # 1
+                        'maxety',    # 2
+                        'maxrl',     # 3
+                        'nnod',      # 4
+                        'nelm',      # 5
+                        'maxcsy',    # 6
+                        'ptrETY',    # 7
+                        'ptrREL',    # 8
+                        'ptrLOC',    # 9
+                        'ptrCSY',    # 10
+                        'ptrEID',    # 11
+                        'maxsec',    # 12
+                        'secsiz',    # 13
+                        'nummat',    # 14
+                        'matsiz',    # 15
+                        'ptrMAS',    # 16
+                        'csysiz',    # 17
+                        'elmsiz',    # 18
+                        'etysiz',    # 19
+                        'rlsiz',     # 20
+                        'ptrETYl',   # 21
+                        'ptrETYh',   # 22
+                        'ptrRELl',   # 23
+                        'ptrRELh',   # 24
+                        'ptrCSYl',   # 25
+                        'ptrCSYh',   # 26
+                        'ptrLOCl',   # 27
+                        'ptrLOCh',   # 28
+                        'ptrEIDl',   # 29
+                        'ptrEIDh',   # 30
+                        'ptrMASl',   # 31
+                        'ptrMASh',   # 32
+                        'ptrSECl',   # 33
+                        'ptrSECh',   # 34
+                        'ptrMATl',   # 35
+                        'ptrMATh',   # 36
+                        'ptrCNTl',   # 37
+                        'ptrCNTh',   # 38
+                        'ptrNODl',   # 39
+                        'ptrNODh',   # 40
+                        'ptrELMl',   # 41
+                        'ptrELMh',   # 42
+                        'Glblenb',   # 43
+                        'ptrGNODl',  # 44
+                        'ptrGNODh',  # 45
+                        'maxn',      # 46
+                        'NodesUpd',  # 47
+                        'lenbac',    # 48
+                        'maxcomp',   # 49
+                        'compsiz',   # 50
+                        'ptrCOMPl',  # 51
+                        'ptrCOMPh',  # 52
+                        'nMatProp',  # 53
+                        'nStage',    # 54
+                        'maxMSsz',   # 55
+                        'ptrMSl',    # 56
+                        'ptrMSh',    # 57
+                        'nCycP',     # 58
+                        'ptrCycPl',  # 59
+                        'ptrCycPh',  # 60
+                        'numety',    # 61
+                        'numrl',     # 62
+                        'numcsy',    # 63
+                        'numsec',    # 64
+                        'mapFlag',   # 65
+                        'cysCSID'    # 66
+]
 
 # FROM fdresu.inc
 # maxety - the maximum element type reference number in the model
@@ -72,7 +91,8 @@ geometry_header_keys = ['__unused',  # position not used
 # csysiz - the number of items describing a local coordinate system (usually 24)
 # elmsiz - the maximum number of nodes that a defined element may have
 # etysiz - the number of items describing an element type(=IELCSZ from echprm.inc)
-# rlsiz  - the maximum number of items defining a real constant (0, if no real constants are defined)
+# rlsiz  - the maximum number of items defining a real constant (0, if
+#           no real constants are defined)
 # ETYl,h - 64 bit pointer to element type data
 # RELl,h - 64 bit pointer to real constant data
 # CSYl,h - 64 bit pointer to coordinate system data
@@ -83,9 +103,41 @@ geometry_header_keys = ['__unused',  # position not used
 # CNTl,h - 64 bit pointer to element centroids
 # NODl,h - 64 bit pointer to nodal equivalence table
 # ELMl,h - 64 bit pointer to element equivalence table
-# lbnnod - global number of nodes actually used in the solution phase (== nnod unless using Distributed Ansys)
-# GNODl,h- 64 bit pointer to the global nodal equivalence table (only used with Distributed ANSYS and when the mesh does not change during solution)
-# maxn   - maximum node number of the model
+# lbnnod - global number of nodes actually used in the solution phase
+#          (== nnod unless using Distributed Ansys)
+# GNODl,h- 64 bit pointer to the global nodal equivalence table (only
+#          used with Distributed ANSYS and when the mesh does not change during
+#          solution)
+# maxn     - maximum node number of the model
+# NodesUpd - 1, node coords have been updated
+# lenbac   - the actual number of nodes used in the solution phase
+# numcomp  - number of components/assemblies stored (only node/elem
+#            components/assemblies)
+# mxcmpsz  - maximum size (in integer words) that any
+#            component/assembly record may have
+# ptrCOMPl,h - 64 bit pointer to component/assembly data
+# nMatProp - number of properties stored per material
+# nStage   - number of stages
+# maxMSsz  - maximum size (in integer words) that a
+#            stage record can have
+# ptrMSl,h - 64 bit pointer to multistage (MS) cyclic
+#            analysis data
+# nCycP    - number of cyclic edge node pair tables (CYCLIC and MS)
+# ptrCycPl,h - pointers to cyclic edge node pair tables
+# numety   - the number of defined element types
+#            in the model
+# numrl    - the number of defined real constants in the model
+# numcsy   - the number of defined coordinate
+#            systems in the model
+# numsec   - the number of defined sections in the model
+# mapFlag  - flag to indicate format of mapping index vectors for
+#            element types, real constants, coordinate systems, and
+#            sections.
+#            = 0, old format with 1 vector of maxDef len
+#            = 1, new format with 2 vectors each having numDef len
+# cycCSID  - coordinate system number (CYCLIC and MS)
+#            = 0 is ignored (must be cylindrical)
+
 
 
 element_index_table_info = {

--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 19
+version_info = 0, 44, 20
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/cython/_binary_reader.pyx
+++ b/pyansys/cython/_binary_reader.pyx
@@ -14,10 +14,6 @@ from libc.string cimport memcpy
 from libc.stdint cimport int64_t, int32_t
 from libc.stdlib cimport malloc, free
 
-# debug
-from libc.stdio cimport printf
-
-
 from cython.parallel import prange
 ctypedef unsigned char uint8
 

--- a/pyansys/cython/_reader.pyx
+++ b/pyansys/cython/_reader.pyx
@@ -301,7 +301,7 @@ def read(filename, read_parameters=False, debug=False):
                     continue
                 start_pos = n
                 if debug:
-                    print('reading NBLOCK')
+                    print('reading NBLOCK due to ', line.decode())
 
                 nodes_read = True
                 # Get size of NBLOCK
@@ -319,40 +319,45 @@ def read(filename, read_parameters=False, debug=False):
                 nnodes_read = read_nblock(raw, &nnum[0], &nodes[0, 0], nnodes,
                                           &d_size[0], f_size, &n)
 
-                # verify at the end of the block
                 if nnodes_read != nnodes:
                     nnodes = nnodes_read
                     nodes = nodes[:nnodes]
                     nnum = nnum[:nnodes]
-                else:
-                    if myfgets(line, raw, &n, fsize):
-                        raise RuntimeError('Unable to read nblock format line or '
-                                           'at end of file.')
 
-                    bl_end = line.decode().replace(' ', '')
-                    if 'N,R5.3,LOC' not in bl_end or b'-1' == bl_end[:2]:
-                        if debug:
-                            print('N,R5.3,LOC not at end of block')
-                        # need to reread the number of nodes
-                        n = start_pos
-                        if myfgets(line, raw, &n, fsize): raise Exception(badstr)
-                        nnodes = 0
-                        while True:
-                            if myfgets(line, raw, &n, fsize): raise Exception(badstr)
-                            bl_end = line.decode().replace(' ', '')
-                            if 'N,R5.3,LOC' not in bl_end or b'-1' == bl_end[:2]:
-                                break
-                            nnodes += 1
+                # # verify at the end of the block
+                # if nnodes_read != nnodes:
+                #     nnodes = nnodes_read
+                #     nodes = nodes[:nnodes]
+                #     nnum = nnum[:nnodes]
+                # else:
+                #     if myfgets(line, raw, &n, fsize):
+                #         raise RuntimeError('Unable to read nblock format line or '
+                #                            'at end of file.')
 
-                        # reread nodes
-                        n = start_pos
-                        if myfgets(line, raw, &n, fsize): raise Exception(badstr)
-                        d_size, f_size, nfld, nexp = node_block_format(line)
-                        nnum = np.empty(nnodes, dtype=ctypes.c_int)
-                        nodes = np.zeros((nnodes, 6))
+                #     bl_end = line.decode().replace(' ', '')
+                #     if 'LOC' not in bl_end or b'-1' == bl_end[:2]:
+                #         if debug:
+                #             print('Unable to find the end of the NBLOCK')
+                #         # need to reread the number of nodes
+                #         n = start_pos
+                #         if myfgets(line, raw, &n, fsize): raise Exception(badstr)
+                #         nnodes = 0
+                #         while True:
+                #             if myfgets(line, raw, &n, fsize): raise Exception(badstr)
+                #             bl_end = line.decode().replace(' ', '')
+                #             if 'LOC' not in bl_end or b'-1' == bl_end[:2]:
+                #                 break
+                #             nnodes += 1
 
-                        n = read_nblock(raw, &nnum[0], &nodes[0, 0], nnodes,
-                                        &d_size[0], f_size, &n)
+                #         # reread nodes
+                #         n = start_pos
+                #         if myfgets(line, raw, &n, fsize): raise Exception(badstr)
+                #         d_size, f_size, nfld, nexp = node_block_format(line)
+                #         nnum = np.empty(nnodes, dtype=ctypes.c_int)
+                #         nodes = np.zeros((nnodes, 6))
+
+                #         n = read_nblock(raw, &nnum[0], &nodes[0, 0], nnodes,
+                #                         &d_size[0], f_size, &n)
 
 
         elif 'C' == line[0] or 'c' == line[0]:

--- a/pyansys/parameters.py
+++ b/pyansys/parameters.py
@@ -275,7 +275,11 @@ class Parameters():
 
         parm = parameters[key]
         if parm['type'] in ['ARRAY', 'TABLE']:
-            return self._get_parameter_array(key, parm['shape'])
+            try:
+                return self._get_parameter_array(key, parm['shape'])
+            except ValueError:
+                # allow a second attempt
+                return self._get_parameter_array(key, parm['shape'])
 
         return parm['value']
 

--- a/pyansys/rst.py
+++ b/pyansys/rst.py
@@ -272,7 +272,7 @@ class Result(AnsysBinary):
             csys_record_pointers = self.read_record(ptr_csy + sz)
         else:
             maxcsy = self._geometry_header['maxcsy']
-            csys_record_pointers = csys_record_pointers[:maxcsy]
+            csys_record_pointers = csy[:maxcsy]
 
         # parse each coordinate system
         # The items stored in each record:

--- a/pyansys/rst.py
+++ b/pyansys/rst.py
@@ -228,10 +228,10 @@ class Result(AnsysBinary):
         Returns
         -------
         c_systems : dict
-            Dictionary containing one entry for each defined coordinate
-            system.  If no non-standard coordinate systems have been
-            defined, there will be only one None.  First coordinate system
-            is assumed to be global cartesian.
+            Dictionary containing one entry for each defined
+            coordinate system.  If no non-standard coordinate systems
+            have been defined, there will be only one None.  First
+            coordinate system is assumed to be global cartesian.
 
         Notes
         -----
@@ -242,14 +242,15 @@ class Result(AnsysBinary):
         - Third rotation about local Y (positive Z toward X).
 
         PAR1
-        Used for elliptical, spheroidal, or toroidal systems. If KCS = 1
-        or 2, PAR1 is the ratio of the ellipse Y-axis radius to X-axis
-        radius (defaults to 1.0 (circle)). If KCS = 3, PAR1 is the major
-        radius of the torus.
+        Used for elliptical, spheroidal, or toroidal systems. If KCS =
+        1 or 2, PAR1 is the ratio of the ellipse Y-axis radius to
+        X-axis radius (defaults to 1.0 (circle)). If KCS = 3, PAR1 is
+        the major radius of the torus.
 
         PAR2
-        Used for spheroidal systems. If KCS = 2, PAR2 = ratio of ellipse
-        Z-axis radius to X-axis radius (defaults to 1.0 (circle)).
+        Used for spheroidal systems. If KCS = 2, PAR2 = ratio of
+        ellipse Z-axis radius to X-axis radius (defaults to 1.0
+        (circle)).
 
         Coordinate system type:
             - 0: Cartesian
@@ -257,13 +258,21 @@ class Result(AnsysBinary):
             - 2: Spherical (or spheroidal)
             - 3: Toroidal
         """
-        # number of coordinate systems
-        maxcsy = self._geometry_header['maxcsy']
+        c_systems = [None]
 
         # load coordinate system index table
         ptr_csy = self._geometry_header['ptrCSY']
         if ptr_csy:
-            csy = self.read_record(ptr_csy)
+            csy, sz = self.read_record(ptr_csy, return_bufsize=True)
+        else:
+            return c_systems
+
+        # Assemble element record pointers relative to ptrETY
+        if self._map_flag:
+            csys_record_pointers = self.read_record(ptr_csy + sz)
+        else:
+            maxcsy = self._geometry_header['maxcsy']
+            csys_record_pointers = csys_record_pointers[:maxcsy]
 
         # parse each coordinate system
         # The items stored in each record:
@@ -274,12 +283,11 @@ class Result(AnsysBinary):
         # * Items 19-20 are theta and phi singularity keys.
         # * Item 21 is the coordinate system type (0, 1, 2, or 3).
         # * Item 22 is the coordinate system reference number.
-        c_systems = [None]
-        for i in range(maxcsy):
-            if not csy[i]:
+        for csys_record_pointer in csys_record_pointers:
+            if not csys_record_pointer:
                 c_system = None
             else:
-                data = self.read_record(ptr_csy + csy[i])
+                data = self.read_record(ptr_csy + csys_record_pointer)
                 c_system = {'transformation matrix': np.array(data[:9].reshape(-1, 3)),
                             'origin': np.array(data[9:12]),
                             'PAR1': data[12],
@@ -1289,12 +1297,22 @@ class Result(AnsysBinary):
 
         return node_comp, elem_comp
 
+    @property
+    def _map_flag(self):
+        """Flag to indicate format of mapping index vectors for
+        element types, real constants, coordinate systems, and sections.
+
+        When ``True``, uses two vectors, and ``False`` using the old
+        format (prior to 2021R1).
+
+        """
+        return bool(self._geometry_header['mapFlag'])
+
     def _load_element_table(self):
         """Store element type information"""
-        maxety = self._geometry_header['maxety']  # number of elemet types
-
         # pointer to the element type index table
-        e_type_table = self.read_record(self._geometry_header['ptrETY'])
+        ptrety = self._geometry_header['ptrETY']
+        e_type_table, sz = self.read_record(ptrety, True)
 
         # store information for each element type
         nodelm = np.empty(10000, np.int32)  # n nodes for this element type
@@ -1302,11 +1320,18 @@ class Result(AnsysBinary):
         nodstr = np.empty(10000, np.int32)  # n nodes per element having nodal stresses
         ekey = []
         keyopts = np.zeros((10000, 11), np.int16)
-        for i in range(maxety):
-            if not e_type_table[i]:
-                continue
 
-            ptr = self._geometry_header['ptrETY'] + e_type_table[i]
+        # Assemble element record pointers relative to ptrETY
+        if self._map_flag:
+            elem_record_pointers = self.read_record(ptrety + sz)
+        else:
+            elem_record_pointers = []
+            for i in range(self._geometry_header['maxety']):
+                if e_type_table[i]:
+                    elem_record_pointers.append(e_type_table[i])
+
+        for elem_record_pointer in elem_record_pointers:
+            ptr = ptrety + elem_record_pointer
             einfo = self.read_record(ptr)
 
             etype_ref = einfo[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from pyansys.errors import MapdlExitedError
 pyvista.OFF_SCREEN = True
 
 # check for a valid MAPDL install with CORBA
-valid_rver = ['202', '201', '195', '194', '193', '192', '191', '190', '182']
+valid_rver = ['211', '202', '201', '195', '194', '193', '192', '191', '190', '182']
 EXEC_FILE = None
 for rver in valid_rver:
     if os.path.isfile(get_ansys_bin(rver)):

--- a/tests/test_binary_reader.py
+++ b/tests/test_binary_reader.py
@@ -99,6 +99,7 @@ def cyclic_modal(mapdl):
 
 @pytest.fixture(scope='module')
 def transient_thermal(mapdl):
+    mapdl.finish()
     mapdl.clear()
     mapdl.prep7()
 
@@ -139,7 +140,6 @@ def transient_thermal(mapdl):
                         [400, 0.002],    # ramps down in 10 seconds
                         [end_time, 0.002]])  # end of third "flat" zone
     mapdl.load_table('my_conv', my_conv, 'TIME')
-
 
     # Create a table of bulk temperatures for a given time and transfer to MAPDL
     my_bulk = np.array([[0, 100],      # start time
@@ -219,11 +219,8 @@ def test_presol_s(mapdl, cyclic_modal, rset):
     ansys_element_stress = ansys_element_stress[:, 1:]
 
     arr_sz = element_stress.shape[0]
-    try:
-        assert np.allclose(element_stress, ansys_element_stress[:arr_sz])
-        assert np.allclose(enode, ansys_enode[:arr_sz])
-    except:
-        breakpoint()    
+    assert np.allclose(element_stress, ansys_element_stress[:arr_sz])
+    assert np.allclose(enode, ansys_enode[:arr_sz])
 
 
 @pytest.mark.parametrize("rset", RSETS)
@@ -471,7 +468,6 @@ def test_file_not_supported():
 def test_nodal_time_history(mapdl, transient_thermal):
     rst = mapdl.result
     nnum, data = rst.nodal_time_history()
-
     assert np.allclose(nnum, mapdl.mesh.nnum)
     for i in range(mapdl.post_processing.nsets):
         mapdl.set(1, i + 1)

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -133,6 +133,7 @@ def test_disp(mapdl, static_solve, comp):
 
     disp_from_grpc = mapdl.post_processing.nodal_displacement(comp)
     mapdl.post1()
+    breakpoint()
     mapdl.set(1, 1)
     nnum, disp_from_prns = data_from_prnsol(mapdl, mapdl.prnsol('U', comp)).T
     assert np.allclose(mapdl.mesh.nnum, nnum)

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -133,7 +133,6 @@ def test_disp(mapdl, static_solve, comp):
 
     disp_from_grpc = mapdl.post_processing.nodal_displacement(comp)
     mapdl.post1()
-    breakpoint()
     mapdl.set(1, 1)
     nnum, disp_from_prns = data_from_prnsol(mapdl, mapdl.prnsol('U', comp)).T
     assert np.allclose(mapdl.mesh.nnum, nnum)


### PR DESCRIPTION
The upcoming 2021R1 release contains the `mapFlag` value within fdresu.inc, indicating that there are now two formats for writing index vectors for element types, real constants, coordinate systems, and sections.  This has been updated accordingly along with some minor changes to the archive reader.

Bumps to ``pyansys=0.44.20``.
