### PR TITLE
Fix rst to VTK and MAPDL Collection

### DIFF
--- a/pyansys/_version.py
+++ b/pyansys/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 44, 20
+version_info = 0, 44, 21
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -1888,6 +1888,9 @@ class _MapdlCore(_MapdlCommands):
             self._path = self.inquire('DIRECTORY')
         except:
             pass
+
+        # os independent path format
+        self._path = self._path.replace('\\', '/')
         return self._path
 
     @property
@@ -1903,14 +1906,15 @@ class _MapdlCore(_MapdlCommands):
 
     def __del__(self):  # pragma: no cover
         """Clean up when complete"""
-        if self._cleanup:
-            try:
-                self.exit()
-            except Exception as e:
-                try:  # logger might be closed
-                    self._log.error('exit: %s', str(e))
-                except:
-                    pass
+        if hasattr(self, '_cleanup'):
+            if self._cleanup:
+                try:
+                    self.exit()
+                except Exception as e:
+                    try:  # logger might be closed
+                        self._log.error('exit: %s', str(e))
+                    except:
+                        pass
 
     @supress_logging
     def get_array(self, entity='', entnum='', item1='', it1num='', item2='',

--- a/pyansys/mapdl_corba.py
+++ b/pyansys/mapdl_corba.py
@@ -75,7 +75,7 @@ def launch_corba(exec_file=None, run_location=None, jobname=None, nproc=None,
     if os.path.isfile(broadcast_file):
         os.remove(broadcast_file)
 
-    subprocess.Popen(command, shell=False,
+    subprocess.Popen(command, shell=True,
                      cwd=run_location,
                      stdin=subprocess.DEVNULL,
                      stdout=subprocess.DEVNULL,

--- a/pyansys/rst.py
+++ b/pyansys/rst.py
@@ -1954,11 +1954,9 @@ class Result(AnsysBinary):
         enode = []
         nnode = nodstr[etype]
         if sort:
-            for i in sidx:
-                enode.append(self._mesh.elem[i][10:10+nnode[i]])
+            enode = [self._mesh.elem[i][10:10+nnode[i]] for i in sidx]
         else:
-            for i in range(enum.size):
-                enode.append(self._mesh.elem[i][10:10+nnode[i]])
+            enode = [self._mesh.elem[i][10:10+nnode[i]] for i in range(enum.size)]
 
         return enum, element_data, enode
 
@@ -2674,7 +2672,7 @@ class Result(AnsysBinary):
 
         """
         # Copy grid as to not write results to original object
-        grid = self.grid.copy()
+        grid = self.quadgrid.copy()
 
         if rsets is None:
             rsets = range(self.nsets)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ from pyansys.errors import MapdlExitedError
 pyvista.OFF_SCREEN = True
 
 # check for a valid MAPDL install with CORBA
-valid_rver = ['211', '202', '201', '195', '194', '193', '192', '191', '190', '182']
+# valid_rver = ['211', '202', '201', '195', '194', '193', '192', '191', '190', '182']
+valid_rver = ['202', '201', '195', '194', '193', '192', '191', '190', '182']
 EXEC_FILE = None
 for rver in valid_rver:
     if os.path.isfile(get_ansys_bin(rver)):


### PR DESCRIPTION
### Minor Bug Patches


#### CORBA Collection 
This PR fixes a MAPDL CORBA collection bug whereby on when attempting to collect an exited instance of MAPDL CORBA, Python repeately tries to exit an already exited server, locking the instance.  Resolves #320


#### RST to VTK
By default the result writer saves the ``linear_copy`` of the unstructured mesh of result.  This causes issues when `meshio` expects the number of points to match the cell type.  `pyansys` now always saves the quadratic file.  Resolves #322.
