### PR TITLE
limit reader version for doc build

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -12,5 +12,5 @@ sphinx-copybutton
 sphinx-gallery>=0.8.1
 sphinx-autodoc-typehints
 pyansys_sphinx_theme
-pypandoc
 Jinja2==2.11.3  # due to An error happened in rendering the page genindex. with v3
+ansys-mapdl-reader<=0.51.3  # 0.51.4-0.51.5 breaks doc build


### PR DESCRIPTION
Resolve broken docbuild in #554 due to bug in upstream `ansys-mapdl-reader`.

Replaces #555﻿
