### PR TITLE
Executing invalid commands from run if we are in non_interactive mode

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -2067,13 +2067,13 @@ class _MapdlCore(Commands):
         if self._store_commands:
             self._stored_commands.append(command)
             return
-        elif command[:3].upper() in INVAL_COMMANDS:
+        elif command[:3].upper() in INVAL_COMMANDS and not self.non_interactive:
             exception = RuntimeError(
                 'Invalid pymapdl command "%s"\n\n%s'
                 % (command, INVAL_COMMANDS[command[:3].upper()])
             )
             raise exception
-        elif command[:4].upper() in INVAL_COMMANDS:
+        elif command[:4].upper() in INVAL_COMMANDS and not self.non_interactive:
             exception = RuntimeError(
                 'Invalid pymapdl command "%s"\n\n%s'
                 % (command, INVAL_COMMANDS[command[:4].upper()])


### PR DESCRIPTION
Executing invalid commands in ``non_interactive`` mode should be allowed even if we are using ``run`` command. 