### PR TITLE
fix: remove duplicate `list-instances` entry from CLI help

### DIFF
--- a/doc/changelog.d/4542.fixed.md
+++ b/doc/changelog.d/4542.fixed.md
@@ -1,0 +1,1 @@
+Remove duplicate \`list-instances\` entry from CLI help

--- a/src/ansys/mapdl/core/cli/list_instances.py
+++ b/src/ansys/mapdl/core/cli/list_instances.py
@@ -25,7 +25,7 @@ import click
 
 @click.command(
     short_help="List MAPDL running instances.",
-    help="""This command list MAPDL instances""",
+    help="""This command lists MAPDL instances.""",
 )
 @click.option(
     "--instances",

--- a/src/ansys/mapdl/core/cli/list_instances.py
+++ b/src/ansys/mapdl/core/cli/list_instances.py
@@ -22,10 +22,8 @@
 
 import click
 
-from ansys.mapdl.core.cli import main
 
-
-@main.command(
+@click.command(
     short_help="List MAPDL running instances.",
     help="""This command list MAPDL instances""",
 )


### PR DESCRIPTION
The `list_instances` command was registered twice:
- Once automatically via `@main.command()` decorator (as `list-instances`)
- Once explicitly via `main.add_command(list_instances, name='list')` in `__init__.py`

This caused both `list` and `list-instances` to appear in `pymapdl --help`.

Fix by changing the decorator to `@click.command()` so the command is only registered once (as `list`) through the explicit `add_command` call in `__init__.py`. Also removes the now-unnecessary `from ansys.mapdl.core.cli import main` import.
