### PR TITLE
feat: Add `docker/run` tox environments for starting and stopping MAPDL/DPF containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,7 @@ jobs:
           FILE_NAME: ${{ env.file_name }}
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uvx tox -e docker-remote
+          uvx tox -e docker-test-remote
 
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
         name: "Upload coverage to Codecov"
@@ -457,7 +457,7 @@ jobs:
           FILE_NAME: ${{ env.file_name }}
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uvx tox -e docker-local
+          uvx tox -e docker-test-local
 
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
         name: "Upload coverage to Codecov"

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ doc/webserver.pid
 
 # Profiling
 prof
+docker/run/.env
+docker/testing/.env

--- a/doc/changelog.d/4552.added.md
+++ b/doc/changelog.d/4552.added.md
@@ -1,0 +1,1 @@
+Add \`docker/run\` tox environments for starting and stopping MAPDL/DPF containers

--- a/docker/run/compose.py
+++ b/docker/run/compose.py
@@ -1,0 +1,44 @@
+"""Cross-platform wrapper for docker compose in docker/run.
+
+Runs ``docker compose`` with ``--env-file .env`` when the file exists in the
+same directory, otherwise omits it so shell-exported variables are used instead.
+
+Usage (via tox)::
+
+    {envpython} {toxinidir}/docker/run/compose.py --profile mapdl up -d
+    {envpython} {toxinidir}/docker/run/compose.py --profile mapdl down
+"""
+
+import os
+from pathlib import Path
+import subprocess  # nosec B404
+import sys
+
+_HERE = Path(__file__).parent
+
+
+def main() -> None:
+    env_file = _HERE / ".env"
+    compose_file = _HERE / "docker-compose.yml"
+
+    cmd = ["docker", "compose", "-f", str(compose_file)]
+    if env_file.exists():
+        cmd += ["--env-file", str(env_file)]
+    else:
+        if not os.environ.get("ANSYSLMD_LICENSE_FILE"):
+            sys.exit(
+                "ERROR: ANSYSLMD_LICENSE_FILE is not set. Add it to docker/run/.env or export it in your shell."
+            )
+
+        if not os.environ.get("DOCKER_IMAGE"):
+            sys.exit(
+                "ERROR: DOCKER_IMAGE is not set. Add it to docker/run/.env or export it in your shell."
+            )
+
+    cmd += sys.argv[1:]
+
+    sys.exit(subprocess.call(cmd))  # nosec B603
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/run/example.env
+++ b/docker/run/example.env
@@ -1,0 +1,33 @@
+# Credentials for docker/run docker compose environments.
+# Copy this file to .env in the same directory and fill in the values:
+#
+#   cp docker/run/example.env docker/run/.env
+#
+# Then start services with:
+#
+#   tox -e docker-run-mapdl        # start MAPDL only
+#   tox -e docker-run-mapdl-dpf   # start MAPDL and DPF
+#
+# The .env file is gitignored and will never be committed.
+
+# -----------------------------------------------------------------------
+# Required
+# -----------------------------------------------------------------------
+ANSYSLMD_LICENSE_FILE=1055@11.22.33.44
+DOCKER_IMAGE=myregistry.com/myregistryuser/myansysimage:latest
+
+# -----------------------------------------------------------------------
+# Optional — only needed when using the mapdl-dpf profile
+# -----------------------------------------------------------------------
+DPF_DOCKER_IMAGE=myregistry.com/myregistryuser/mydpfimage:latest
+
+# -----------------------------------------------------------------------
+# Optional — MAPDL version and path inside the container
+# -----------------------------------------------------------------------
+# AWP_ROOT=AWP_ROOT251
+# AWP_ROOT_VALUE=/ansys_inc
+
+# -----------------------------------------------------------------------
+# Optional — username inside the container (default: mapdl)
+# -----------------------------------------------------------------------
+# DOCKER_USER=mapdl

--- a/docker/testing/compose.py
+++ b/docker/testing/compose.py
@@ -1,0 +1,43 @@
+"""Cross-platform wrapper for docker compose in docker/testing.
+
+Runs ``docker compose`` with ``--env-file .env`` when the file exists in the
+same directory, otherwise omits it so shell-exported variables are used instead.
+
+Usage (via tox)::
+
+    {envpython} {toxinidir}/docker/testing/compose.py --profile remote-host up ...
+    {envpython} {toxinidir}/docker/testing/compose.py --profile local-host up ...
+"""
+
+import os
+from pathlib import Path
+import subprocess  # nosec B404
+import sys
+
+_HERE = Path(__file__).parent
+
+
+def main() -> None:
+    env_file = _HERE / ".env"
+    compose_file = _HERE / "docker-compose.yml"
+
+    cmd = ["docker", "compose", "-f", str(compose_file)]
+    if env_file.exists():
+        cmd += ["--env-file", str(env_file)]
+    else:
+        if not os.environ.get("ANSYSLMD_LICENSE_FILE"):
+            sys.exit(
+                "ERROR: ANSYSLMD_LICENSE_FILE is not set. Add it to docker/testing/.env or export it in your shell."
+            )
+
+        if not os.environ.get("DOCKER_IMAGE"):
+            sys.exit(
+                "ERROR: DOCKER_IMAGE is not set. Add it to docker/testing/.env or export it in your shell."
+            )
+    cmd += sys.argv[1:]
+
+    sys.exit(subprocess.call(cmd))  # nosec B603
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/testing/example.env
+++ b/docker/testing/example.env
@@ -5,10 +5,10 @@
 #
 # Then run tests with:
 #
-#   tox -e docker-remote          # full run (remote MAPDL + host PyMAPDL)
-#   tox -e docker-local           # full run (local MAPDL + host PyMAPDL)
-#   tox -e docker-run-remote      # run pytest in a fresh container from the cached image
-#   tox -e docker-run-local       # run pytest in a fresh container from the cached image
+#   tox -e docker-test-remote          # full run (remote MAPDL + host PyMAPDL)
+#   tox -e docker-test-local           # full run (local MAPDL + host PyMAPDL)
+#   tox -e docker-test-run-remote      # run pytest in a fresh container from the cached image
+#   tox -e docker-test-run-local       # run pytest in a fresh container from the cached image
 #
 # The .env file is gitignored and will never be committed.
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,14 +55,13 @@ description =
 skip_install = true
 allowlist_externals =
     docker
-env_files =
-    {toxinidir}/docker/run/.env
 passenv =
     ANSYSLMD_LICENSE_FILE
     DOCKER_IMAGE
 commands =
     docker compose \
         -f {toxinidir}/docker/run/docker-compose.yml \
+        --env-file {toxinidir}/docker/run/.env \
         --profile mapdl \
         up \
         -d
@@ -73,17 +72,14 @@ description =
 skip_install = true
 allowlist_externals =
     docker
-env_files =
-    {toxinidir}/docker/run/.env
 passenv =
     ANSYSLMD_LICENSE_FILE
     DOCKER_IMAGE
     DPF_DOCKER_IMAGE
-commands_pre =
-    {envpython} -c "import os,sys; sys.exit('ERROR: ANSYSLMD_LICENSE_FILE is not set. Add it to docker/run/.env or export it in your shell.') if not os.environ.get('ANSYSLMD_LICENSE_FILE') else None"
 commands =
     docker compose \
         -f {toxinidir}/docker/run/docker-compose.yml \
+        --env-file {toxinidir}/docker/run/.env \
         --profile mapdl-dpf \
         up \
         -d
@@ -94,13 +90,12 @@ description =
 skip_install = true
 allowlist_externals =
     docker
-env_files =
-    {toxinidir}/docker/run/.env
 passenv =
     DOCKER_IMAGE
 commands =
     docker compose \
         -f {toxinidir}/docker/run/docker-compose.yml \
+        --env-file {toxinidir}/docker/run/.env \
         --profile mapdl \
         down
 
@@ -110,14 +105,13 @@ description =
 skip_install = true
 allowlist_externals =
     docker
-env_files =
-    {toxinidir}/docker/run/.env
 passenv =
     DOCKER_IMAGE
     DPF_DOCKER_IMAGE
 commands =
     docker compose \
         -f {toxinidir}/docker/run/docker-compose.yml \
+        --env-file {toxinidir}/docker/run/.env \
         --profile mapdl-dpf \
         down
 
@@ -140,13 +134,12 @@ description =
 skip_install = true
 allowlist_externals =
     docker
-env_files =
-    {toxinidir}/docker/testing/.env
 passenv =
     DOCKER_IMAGE
 commands =
     docker compose \
         -f {toxinidir}/docker/testing/docker-compose.yml \
+        --env-file {toxinidir}/docker/testing/.env \
         --profile remote-host \
         build \
         --no-cache
@@ -157,13 +150,12 @@ description =
 skip_install = true
 allowlist_externals =
     docker
-env_files =
-    {toxinidir}/docker/testing/.env
 passenv =
     DOCKER_IMAGE
 commands =
     docker compose \
         -f {toxinidir}/docker/testing/docker-compose.yml \
+        --env-file {toxinidir}/docker/testing/.env \
         --profile local-host \
         build \
         --no-cache
@@ -176,8 +168,6 @@ skip_install = true
 allowlist_externals =
     docker
     python
-env_files =
-    {toxinidir}/docker/testing/.env
 setenv =
     PYTEST_ARGUMENTS = {posargs:{env:PYTEST_ARGUMENTS:}}
 passenv =
@@ -186,12 +176,11 @@ passenv =
     FILE_NAME
     ON_CI
     PYTEST_ARGUMENTS
-commands_pre =
-    {envpython} -c "import os,sys; sys.exit('ERROR: ANSYSLMD_LICENSE_FILE is not set. Add it to docker/testing/.env or export it in your shell.') if not os.environ.get('ANSYSLMD_LICENSE_FILE') else None"
 commands =
     docker compose \
         -f {toxinidir}/docker/testing/docker-compose.yml \
         --profile remote-host \
+        --env-file {toxinidir}/docker/testing/.env \
         up \
         --abort-on-container-exit \
         --exit-code-from pymapdl-host \
@@ -206,8 +195,6 @@ skip_install = true
 allowlist_externals =
     docker
     python
-env_files =
-    {toxinidir}/docker/testing/.env
 setenv =
     PYTEST_ARGUMENTS = {posargs:{env:PYTEST_ARGUMENTS:}}
 passenv =
@@ -216,11 +203,10 @@ passenv =
     FILE_NAME
     ON_CI
     PYTEST_ARGUMENTS
-commands_pre =
-    {envpython} -c "import os,sys; sys.exit('ERROR: ANSYSLMD_LICENSE_FILE is not set. Add it to docker/testing/.env or export it in your shell.') if not os.environ.get('ANSYSLMD_LICENSE_FILE') else None"
 commands =
     docker compose \
         -f {toxinidir}/docker/testing/docker-compose.yml \
+        --env-file {toxinidir}/docker/testing/.env \
         --profile local-host \
         up \
         --abort-on-container-exit \

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,90 @@ extras = doc
 commands =
     sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxworkdir}/doc_out" --color -vW -bhtml
 
+# =============================================================================
+# Docker run environments
+# =============================================================================
+# Copy docker/run/example.env to docker/run/.env and fill in your
+# credentials. If the file does not exist, environment variables from the
+# shell are used as-is.
+#
+# Usage:
+#   tox -e docker-run-mapdl        # start MAPDL service only
+#   tox -e docker-run-mapdl-dpf   # start MAPDL and DPF services
+#   tox -e docker-stop-mapdl       # stop MAPDL service
+#   tox -e docker-stop-mapdl-dpf  # stop MAPDL and DPF services
+
+[testenv:docker-run-mapdl]
+description =
+    Start the MAPDL service using the docker/run/docker-compose.yml file.
+skip_install = true
+allowlist_externals =
+    docker
+env_files =
+    {toxinidir}/docker/run/.env
+passenv =
+    ANSYSLMD_LICENSE_FILE
+    DOCKER_IMAGE
+commands =
+    docker compose \
+        -f {toxinidir}/docker/run/docker-compose.yml \
+        --profile mapdl \
+        up \
+        -d
+
+[testenv:docker-run-mapdl-dpf]
+description =
+    Start the MAPDL and DPF services using the docker/run/docker-compose.yml file.
+skip_install = true
+allowlist_externals =
+    docker
+env_files =
+    {toxinidir}/docker/run/.env
+passenv =
+    ANSYSLMD_LICENSE_FILE
+    DOCKER_IMAGE
+    DPF_DOCKER_IMAGE
+commands_pre =
+    {envpython} -c "import os,sys; sys.exit('ERROR: ANSYSLMD_LICENSE_FILE is not set. Add it to docker/run/.env or export it in your shell.') if not os.environ.get('ANSYSLMD_LICENSE_FILE') else None"
+commands =
+    docker compose \
+        -f {toxinidir}/docker/run/docker-compose.yml \
+        --profile mapdl-dpf \
+        up \
+        -d
+
+[testenv:docker-stop-mapdl]
+description =
+    Stop the MAPDL service started by docker-run-mapdl.
+skip_install = true
+allowlist_externals =
+    docker
+env_files =
+    {toxinidir}/docker/run/.env
+passenv =
+    DOCKER_IMAGE
+commands =
+    docker compose \
+        -f {toxinidir}/docker/run/docker-compose.yml \
+        --profile mapdl \
+        down
+
+[testenv:docker-stop-mapdl-dpf]
+description =
+    Stop the MAPDL and DPF services started by docker-run-mapdl-dpf.
+skip_install = true
+allowlist_externals =
+    docker
+env_files =
+    {toxinidir}/docker/run/.env
+passenv =
+    DOCKER_IMAGE
+    DPF_DOCKER_IMAGE
+commands =
+    docker compose \
+        -f {toxinidir}/docker/run/docker-compose.yml \
+        --profile mapdl-dpf \
+        down
 
 # =============================================================================
 # Docker testing environments
@@ -45,12 +129,12 @@ commands =
 # shell are used as-is.
 #
 # Usage:
-#   tox -e docker-remote           # full run, rebuild image
-#   tox -e docker-local            # full run, rebuild image
-#   tox -e docker-remote-build     # rebuild image only, do not run tests
-#   tox -e docker-local-build      # rebuild image only, do not run tests
+#   tox -e docker-test-remote           # full run, rebuild image
+#   tox -e docker-test-local            # full run, rebuild image
+#   tox -e docker-test-remote-build     # rebuild image only, do not run tests
+#   tox -e docker-test-local-build      # rebuild image only, do not run tests
 
-[testenv:docker-remote-build]
+[testenv:docker-test-remote-build]
 description =
     Rebuild the pymapdl-host image without running tests.
 skip_install = true
@@ -67,7 +151,7 @@ commands =
         build \
         --no-cache
 
-[testenv:docker-local-build]
+[testenv:docker-test-local-build]
 description =
     Rebuild the mapdl-local-host image without running tests.
 skip_install = true
@@ -84,7 +168,7 @@ commands =
         build \
         --no-cache
 
-[testenv:docker-remote]
+[testenv:docker-test-remote]
 description =
     Build image and run tests with remote MAPDL (container) + host PyMAPDL.
     Equivalent to: docker compose --profile remote-host up --abort-on-container-exit
@@ -114,7 +198,7 @@ commands =
         --no-log-prefix \
         --attach pymapdl-host
 
-[testenv:docker-local]
+[testenv:docker-test-local]
 description =
     Build image and run tests with local MAPDL (inside the same container as PyMAPDL).
     Equivalent to: docker compose --profile local-host up --abort-on-container-exit

--- a/tox.ini
+++ b/tox.ini
@@ -53,67 +53,41 @@ commands =
 description =
     Start the MAPDL service using the docker/run/docker-compose.yml file.
 skip_install = true
-allowlist_externals =
-    docker
 passenv =
     ANSYSLMD_LICENSE_FILE
     DOCKER_IMAGE
 commands =
-    docker compose \
-        -f {toxinidir}/docker/run/docker-compose.yml \
-        --env-file {toxinidir}/docker/run/.env \
-        --profile mapdl \
-        up \
-        -d
+    {envpython} {toxinidir}/docker/run/compose.py --profile mapdl up -d
 
 [testenv:docker-run-mapdl-dpf]
 description =
     Start the MAPDL and DPF services using the docker/run/docker-compose.yml file.
 skip_install = true
-allowlist_externals =
-    docker
 passenv =
     ANSYSLMD_LICENSE_FILE
     DOCKER_IMAGE
     DPF_DOCKER_IMAGE
 commands =
-    docker compose \
-        -f {toxinidir}/docker/run/docker-compose.yml \
-        --env-file {toxinidir}/docker/run/.env \
-        --profile mapdl-dpf \
-        up \
-        -d
+    {envpython} {toxinidir}/docker/run/compose.py --profile mapdl-dpf up -d
 
 [testenv:docker-stop-mapdl]
 description =
     Stop the MAPDL service started by docker-run-mapdl.
 skip_install = true
-allowlist_externals =
-    docker
 passenv =
     DOCKER_IMAGE
 commands =
-    docker compose \
-        -f {toxinidir}/docker/run/docker-compose.yml \
-        --env-file {toxinidir}/docker/run/.env \
-        --profile mapdl \
-        down
+    {envpython} {toxinidir}/docker/run/compose.py --profile mapdl down
 
 [testenv:docker-stop-mapdl-dpf]
 description =
     Stop the MAPDL and DPF services started by docker-run-mapdl-dpf.
 skip_install = true
-allowlist_externals =
-    docker
 passenv =
     DOCKER_IMAGE
     DPF_DOCKER_IMAGE
 commands =
-    docker compose \
-        -f {toxinidir}/docker/run/docker-compose.yml \
-        --env-file {toxinidir}/docker/run/.env \
-        --profile mapdl-dpf \
-        down
+    {envpython} {toxinidir}/docker/run/compose.py --profile mapdl-dpf down
 
 # =============================================================================
 # Docker testing environments
@@ -132,14 +106,10 @@ commands =
 description =
     Rebuild the pymapdl-host image without running tests.
 skip_install = true
-allowlist_externals =
-    docker
 passenv =
     DOCKER_IMAGE
 commands =
-    docker compose \
-        -f {toxinidir}/docker/testing/docker-compose.yml \
-        --env-file {toxinidir}/docker/testing/.env \
+    {envpython} {toxinidir}/docker/testing/compose.py \
         --profile remote-host \
         build \
         --no-cache
@@ -148,14 +118,10 @@ commands =
 description =
     Rebuild the mapdl-local-host image without running tests.
 skip_install = true
-allowlist_externals =
-    docker
 passenv =
     DOCKER_IMAGE
 commands =
-    docker compose \
-        -f {toxinidir}/docker/testing/docker-compose.yml \
-        --env-file {toxinidir}/docker/testing/.env \
+    {envpython} {toxinidir}/docker/testing/compose.py \
         --profile local-host \
         build \
         --no-cache
@@ -165,9 +131,6 @@ description =
     Build image and run tests with remote MAPDL (container) + host PyMAPDL.
     Equivalent to: docker compose --profile remote-host up --abort-on-container-exit
 skip_install = true
-allowlist_externals =
-    docker
-    python
 setenv =
     PYTEST_ARGUMENTS = {posargs:{env:PYTEST_ARGUMENTS:}}
 passenv =
@@ -177,10 +140,8 @@ passenv =
     ON_CI
     PYTEST_ARGUMENTS
 commands =
-    docker compose \
-        -f {toxinidir}/docker/testing/docker-compose.yml \
+    {envpython} {toxinidir}/docker/testing/compose.py \
         --profile remote-host \
-        --env-file {toxinidir}/docker/testing/.env \
         up \
         --abort-on-container-exit \
         --exit-code-from pymapdl-host \
@@ -192,9 +153,6 @@ description =
     Build image and run tests with local MAPDL (inside the same container as PyMAPDL).
     Equivalent to: docker compose --profile local-host up --abort-on-container-exit
 skip_install = true
-allowlist_externals =
-    docker
-    python
 setenv =
     PYTEST_ARGUMENTS = {posargs:{env:PYTEST_ARGUMENTS:}}
 passenv =
@@ -204,9 +162,7 @@ passenv =
     ON_CI
     PYTEST_ARGUMENTS
 commands =
-    docker compose \
-        -f {toxinidir}/docker/testing/docker-compose.yml \
-        --env-file {toxinidir}/docker/testing/.env \
+    {envpython} {toxinidir}/docker/testing/compose.py \
         --profile local-host \
         up \
         --abort-on-container-exit \


### PR DESCRIPTION
## Summary

Adds `tox` environments to conveniently start and stop the MAPDL and DPF services
defined in `docker/run/docker-compose.yml`, along with an `example.env` template
so users know which environment variables to provide.

## Changes

### `tox.ini`

Four new environments under a new **Docker run environments** section:

| Environment | Action |
|---|---|
| `tox -e docker-run-mapdl` | Start the `mapdl` profile (MAPDL gRPC server on ports 50052/50055) |
| `tox -e docker-run-mapdl-dpf` | Start the `mapdl-dpf` profile (MAPDL + DPF on port 50056) |
| `tox -e docker-stop-mapdl` | Stop the `mapdl` profile containers |
| `tox -e docker-stop-mapdl-dpf` | Stop the `mapdl-dpf` profile containers |

All environments:
- set `skip_install = true` (no Python package install needed)
- load credentials from `docker/run/.env` if present, otherwise fall back to shell variables
- pass through only the environment variables required by each profile

### `docker/run/example.env` *(new file)*

Template for the `docker/run/.env` credentials file, documenting:
- **Required**: `ANSYSLMD_LICENSE_FILE`, `DOCKER_IMAGE`
- **Optional** (DPF profile): `DPF_DOCKER_IMAGE`
- **Optional** (MAPDL version/path): `AWP_ROOT`, `AWP_ROOT_VALUE`
- **Optional** (container user): `DOCKER_USER`

## Usage

```bash
# Copy and fill in credentials
cp docker/run/example.env docker/run/.env

# Start MAPDL only
tox -e docker-run-mapdl

# Start MAPDL + DPF
tox -e docker-run-mapdl-dpf

# Stop MAPDL only
tox -e docker-stop-mapdl

# Stop MAPDL + DPF
tox -e docker-stop-mapdl-dpf
```
